### PR TITLE
Add get_backend to provider

### DIFF
--- a/qiskit_ionq_provider/ionq_provider.py
+++ b/qiskit_ionq_provider/ionq_provider.py
@@ -32,6 +32,7 @@ import os
 
 from qiskit.providers import BaseProvider
 from qiskit.providers.providerutils import filter_backends
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
 from . import ionq_backend
 
@@ -96,3 +97,22 @@ class IonQProvider(BaseProvider):
         if name:
             backends = [b for b in self._backends if b.name() == name]
         return filter_backends(backends, **kwargs)
+
+    def get_backend(self, name=None, **kwargs):
+        """Return a single backend matching the specified filtering.
+        Args:
+            name (str): name of the backend.
+            **kwargs: dict used for filtering.
+        Returns:
+            Backend: a backend matching the filtering.
+        Raises:
+            QiskitBackendNotFoundError: if no backend could be found or
+                more than one backend matches the filtering criteria.
+        """
+        backends = self.backends(name, **kwargs)
+        if len(backends) > 1:
+            raise QiskitBackendNotFoundError('More than one backend matches criteria.')
+        if not backends:
+            raise QiskitBackendNotFoundError('No backend matches criteria.')
+
+        return backends[0]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addreses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary
The `IonQProvider` was missing `get_backend()` which is a common way of accessing backends.  This adds it.


### Details and comments


