### PR TITLE
Pass execution_time in API result to time_taken in result model

### DIFF
--- a/qiskit_ionq_provider/ionq_job.py
+++ b/qiskit_ionq_provider/ionq_job.py
@@ -315,7 +315,7 @@ class IonQJob(BaseJob):
                 "backend_version": backend_version,
                 "qobj_id": metadata.get("qobj_id"),
                 "success": success,
-                "time_taken": result.get("execution_time"),
+                "time_taken": result.get("execution_time") / 1000,
             }
         )
 

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -145,7 +145,7 @@ def test_results_meta(formatted_result):
     assert formatted_result.qobj_id == "test_qobj_id"
     assert formatted_result.job_id == "test_id"
     assert formatted_result.success is True
-    assert formatted_result.time_taken == 8
+    assert formatted_result.time_taken == 0.008
 
 
 def test_counts(formatted_result):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addreses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary
IonQ API returns an execution_time for all jobs that's equivalent to time_taken, this passes it along (after converting from ms to s)

Two questions for @mtreinish @nonhermitian:
1. It looks like in some parts of Qiskit, time_taken is expected to be on the base Results class instance, [as implemented here](https://github.com/Qiskit/qiskit-aqua/blob/master/qiskit/aqua/quantum_instance.py#L360) and [here](https://github.com/Qiskit/qiskit-aer/blob/10a41dc00564599b74a2ae60b6d836fecc781b8b/qiskit/providers/aer/backends/aerbackend.py#L267), but it also looks like there's a place for it in Counts as well, [here](https://github.com/Qiskit/qiskit-terra/blob/master/qiskit/result/counts.py#L32). I understand that one's probably for "whole job" and the other for "single experiment," but in our case where they're always one and the same: put it in both places? just the top level? just the bottom level? This is really a style question more than anything; I just don't have the context of intent or use to understand the best course of action.
2. What are the _units_ for time_taken? It looked from poking around that it's seconds — all the docs say is that it's a float — but wanted to confirm before adding.