### PR TITLE
Correctly use Options object

### DIFF
--- a/qiskit_ionq_provider/ionq_backend.py
+++ b/qiskit_ionq_provider/ionq_backend.py
@@ -27,6 +27,8 @@
 
 """IonQ provider backends."""
 
+import warnings
+
 import dateutil.parser
 from qiskit.providers import BackendV1 as Backend
 from qiskit.providers.models import BackendConfiguration
@@ -182,7 +184,14 @@ class IonQBackend(Backend):
         Returns:
             IonQJob: A reference to the job that was submitted.
         """
+        for kwarg in kwargs:
+            if not hasattr(self.options, kwarg):
+                warnings.warn("Option %s is not used by this backend" % kwarg,
+                              UserWarning, stacklevel=2)
+        if 'shots' not in kwargs:
+            kwargs['shots'] = self.options.shots
         passed_args = kwargs
+
         job = ionq_job.IonQJob(
             self,
             None,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addreses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

In #43 the ionq backend object was updated to use BackendV1 and handle
it's user configurable options/settings via an Options object. The goal
of that object is to allow for runtime setting of defaults for all the
user tunable options around running a circuit. The _default_options
class method should return an options object with all the available
options for a backend. The values set in the options object (which can
be changed by users prior to calling run()) should be used as the default
unless overridden by a kwarg with the same name to run(). This commit
fixes the behavior so we're using the options value. It also raises a
warning for users if an unsupported option is used so they know that the
kwarg being passed to run doesn't have any effect.

### Details and comments


