### PR TITLE
bugfix - simulator run should take all kwargs

### DIFF
--- a/qiskit_ionq_provider/ionq_backend.py
+++ b/qiskit_ionq_provider/ionq_backend.py
@@ -186,10 +186,11 @@ class IonQBackend(Backend):
         """
         for kwarg in kwargs:
             if not hasattr(self.options, kwarg):
-                warnings.warn("Option %s is not used by this backend" % kwarg,
-                              UserWarning, stacklevel=2)
-        if 'shots' not in kwargs:
-            kwargs['shots'] = self.options.shots
+                warnings.warn(
+                    "Option %s is not used by this backend" % kwarg, UserWarning, stacklevel=2
+                )
+        if "shots" not in kwargs:
+            kwargs["shots"] = self.options.shots
         passed_args = kwargs
 
         job = ionq_job.IonQJob(
@@ -248,7 +249,7 @@ class IonQSimulatorBackend(IonQBackend):
     """
 
     # pylint: disable=missing-type-doc,missing-param-doc,arguments-differ
-    def run(self, circuit, shots=None):
+    def run(self, circuit, **kwargs):
         """Create and run a job on IonQ's Simulator Backend.
 
         .. WARNING:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addreses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

minor bugfix – we have a custom `run` method to enforce the simulator backend's probabilities-only behavior; it got overlooked when we updated the base IonQBackend and created errors when passing other run kwargs (even ones that are noops in a simulator context), i.e. in the context of library methods that use `qiskit.execute` and similar