### PR TITLE
improve handling for failed and cancelled jobs

### DIFF
--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -112,6 +112,14 @@ class IonQJobError(IonQError, JobError):
     """Errors generated from improper usage of IonQJob objects."""
 
 
+class IonQJobFailureError(IonQError, JobError):
+    """Errors generated from jobs that fail on the API side."""
+
+
+class IonQJobStateError(IonQError, JobError):
+    """Errors generated from attempting to do something to a job that its state would not allow"""
+
+
 class IonQGateError(IonQError, JobError):
     """Errors generated from invalid gate defs
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -85,7 +85,7 @@ def dummy_job_response(job_id, status="completed"):
             "clbit_labels": [["c", 0], ["c", 1]],
             "memory_slots": 2,
             "creg_sizes": [["c", 2]],
-            "name": "test-circuit",
+            "name": job_id,
             "global_phase": 0,
         }
     )
@@ -110,6 +110,41 @@ def dummy_job_response(job_id, status="completed"):
                 "meas_mapped": {"1": 0.499999, "3": 0.5}
             },  # implies measurement map of [1,0]
         },
+        "target": "qpu",
+        "id": job_id,
+    }
+
+
+def dummy_failed_job(job_id):
+    """A dummy response payload for a failed job.
+
+    Args:
+        job_id (str): An arbitrary job id.
+        status (str): A provided status string.
+
+    Returns:
+        dict: A json response dict.
+
+    """
+    qiskit_header = compress_dict_to_metadata_string(
+        {
+            "qubit_labels": [["q", 0], ["q", 1]],
+            "n_qubits": 2,
+            "qreg_sizes": [["q", 2]],
+            "clbit_labels": [["c", 0], ["c", 1]],
+            "memory_slots": 2,
+            "creg_sizes": [["c", 2]],
+            "name": job_id,
+            "global_phase": 0,
+        }
+    )
+    return {
+        "failure": {"error": "example error", "code": "ExampleError"},
+        "status": "failed",
+        "metadata": {"shots": "1", "qiskit_header": qiskit_header},
+        "type": "circuit",
+        "request": 1600000000,
+        "response": 1600000002,
         "target": "qpu",
         "id": job_id,
     }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addreses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

The inclusion of the time_taken field in the results actually messed up the handling for failed jobs — rather than throw a failure error, they threw an unrelated error because the results building method was trying to grab results attributes that didn't exist. This was not covered in tests so we only caught it in a (lucky) live case from Sonika.

In fixing that base bug, I took a look at how the ibm provider handles these failures, as I wasn't crazy about the UX of our current solution — it created silent failures that were hard to introspect/catch/recover from in e.g. iterative programs that use the previous job's output . 

Now, any attempted call to job results throws an error if the job was failed or cancelled, rather than creating a weird "failed job" results object that you have to e.g. try and get counts from or otherwise introspect to know it was a failed job. This is roughly the same behavior that IBMQ uses, so figure it's a reasonable choice.