### PR TITLE
imports AggregationType from qiskit_ionq

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For example, running a Bell State:
 
 ```python
 from qiskit import QuantumCircuit
-from qiskit_ionq.constants import AggregationType
+from qiskit_ionq import AggregationType
 
 # Create a basic Bell State circuit:
 qc = QuantumCircuit(2, 2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

expected usage of `AggregationType` is to import from `qiskit_ionq`

### Details and comments

```python
from qiskit import QuantumCircuit
from qiskit_ionq import AggregationType

qc = QuantumCircuit(2, 2)
qc.h(0)
qc.cx(0, 1)
qc.measure([0, 1], [0, 1])

...
```