### PR TITLE
remove deploy documentation to /documentation

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # This code is part of Qiskit.
@@ -30,5 +29,4 @@ pwd
 # Push to qiskit.org/ecosystem
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to qiskti.org/ecosystem"
-rclone sync --progress ./build/html IBMCOS:qiskit-org-web-resources/documentation/partners/ionq
 rclone sync --progress ./build/html IBMCOS:qiskit-org-web-resources/ecosystem/ionq


### PR DESCRIPTION
Follow up on https://github.com/Qiskit-Partners/qiskit-ionq/pull/117

The documentation is correctly deployed in https://qiskit.org/ecosystem/ionq/ and the https://qiskit.org/documentation/partners/ionq/ redirect is working. So, no need to upload to /documentation anymore.