### PR TITLE
don't raise exception from non-decorated method

### DIFF
--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -82,10 +82,9 @@ class IonQClient:
 
         Args:
             req_path (str): The URL path to make the request to.
-            params (dict, optional): Parameters to include in the request body.
+            params (dict, optional): Parameters to include in the request.
             headers (dict, optional): Headers to include in the request.
             timeout (int, optional): Timeout for the request.
-            query_params (dict, optional): Query parameters to include in the URL.
 
         Raises:
             IonQRetriableError: When a retriable error occurs during the request.
@@ -97,7 +96,6 @@ class IonQClient:
             res = requests.get(
                 req_path, params=params, headers=headers, timeout=timeout
             )
-            res.raise_for_status()
         except requests.exceptions.RequestException as req_exc:
             raise IonQRetriableError(req_exc) from req_exc
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

only uses `exceptions.IonQAPIError.raise_for_status(res)` from decorated methods

### Details and comments
