### PR TITLE
include kwargs to use wait in result

### DIFF
--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -258,8 +258,8 @@ class IonQJob(JobV1):
         """Retrieve job result data.
 
         .. NOTE::
-        :attr:`_result` is populated by :meth:`status`, when the job
-        status has reached a "final" state.
+            :attr:`_result` is populated by :meth:`status`, when the job
+            status has reached a "final" state.
 
         This method calls the
         :meth:`wait_for_final_state <qiskit.providers.BaseJob.wait_for_final_state>`

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -254,12 +254,12 @@ class IonQJob(JobV1):
         """
         return self.result().get_probabilities()
 
-    def result(self, sharpen: bool = None, extra_query_params: dict = None):
+    def result(self, sharpen: bool = None, extra_query_params: dict = None, **kwargs):
         """Retrieve job result data.
 
         .. NOTE::
-           :attr:`_result` is populated by :meth:`status`, when the job
-           status has reached a "final" state.
+        :attr:`_result` is populated by :meth:`status`, when the job
+        status has reached a "final" state.
 
         This method calls the
         :meth:`wait_for_final_state <qiskit.providers.BaseJob.wait_for_final_state>`
@@ -283,7 +283,7 @@ class IonQJob(JobV1):
 
         # Wait for the job to complete.
         try:
-            self.wait_for_final_state()
+            self.wait_for_final_state(**kwargs)
         except JobTimeoutError as ex:
             raise exceptions.IonQJobTimeoutError(
                 "Timed out waiting for job to complete."


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

can run

```python
job = backend.run(qc)
results = job.result(wait=1)  # default is 5 seconds
```

### Details and comments

can get results faster