### PR TITLE
fix incorrect gate aliasing

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -211,7 +211,7 @@ def qiskit_circ_to_ionq_circ(input_circuit, gateset="qis"):
 
         # re-alias certain names
         if instruction_name in ionq_api_aliases:
-            instruction_name = ionq_api_aliases.get(instruction_name)
+            instruction_name = ionq_api_aliases[instruction_name]
             converted["gate"] = instruction_name
 
         # Make sure uncontrolled multi-targets use all qargs.

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -89,7 +89,7 @@ ionq_basis_gates = [
     "z",
 ]
 
-ionq_api_aliases = {
+ionq_api_aliases = {  # todo fix alias bug
     q_gates.p.CPhaseGate: "cz",
     q_gates.sx.CSXGate: "cv",
     q_gates.p.MCPhaseGate: "cz",
@@ -180,15 +180,17 @@ def qiskit_circ_to_ionq_circ(input_circuit, gateset="qis"):
         # Process the instruction and convert.
         rotation = {}
         if len(instruction.params) > 0:
-            if gateset == "qis" or (len(instruction.params) == 1 and instruction_name != 'zz'):
+            if gateset == "qis" or (
+                len(instruction.params) == 1 and instruction_name != "zz"
+            ):
                 # The float is here to cast Qiskit ParameterExpressions to numbers
                 rotation = {
-                    ("rotation"
-                    if gateset == "qis"
-                    else "phase"): float(instruction.params[0])
+                    ("rotation" if gateset == "qis" else "phase"): float(
+                        instruction.params[0]
+                    )
                 }
             elif instruction_name in {"zz"}:
-                rotation = { "angle": instruction.params[0] }
+                rotation = {"angle": instruction.params[0]}
             else:
                 rotation = {
                     "phases": [float(t) for t in instruction.params[:2]],

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -90,22 +90,22 @@ ionq_basis_gates = [
 ]
 
 ionq_api_aliases = {  # todo fix alias bug
-    q_gates.p.CPhaseGate: "cz",
-    q_gates.sx.CSXGate: "cv",
-    q_gates.p.MCPhaseGate: "cz",
-    q_gates.x.CCXGate: "cx",  # just one C for all mcx
-    q_gates.x.C3XGate: "cx",  # just one C for all mcx
-    q_gates.x.C4XGate: "cx",  # just one C for all mcx
-    q_gates.x.MCXGate: "cx",  # just one C for all mcx
-    q_gates.x.MCXGrayCode: "cx",  # just one C for all mcx
-    q_gates.t.TdgGate: "ti",
-    q_gates.p.PhaseGate: "z",
-    q_gates.RXXGate: "xx",
-    q_gates.RYYGate: "yy",
-    q_gates.RZZGate: "zz",
-    q_gates.s.SdgGate: "si",
-    q_gates.sx.SXGate: "v",
-    q_gates.sx.SXdgGate: "vi",
+    "cp": "cz",
+    "csx": "cv",
+    "mcphase": "cz",
+    "ccx": "cx",  # just one C for all mcx
+    "mcx": "cx",  # just one C for all mcx
+    "mcx": "cx",  # just one C for all mcx
+    "mcx": "cx",  # just one C for all mcx
+    "mcx_gray": "cx",  # just one C for all mcx
+    "tdg": "ti",
+    "p": "z",
+    "rxx": "xx",
+    "ryy": "yy",
+    "rzz": "zz",
+    "sdg": "si",
+    "sx": "v",
+    "sxdg": "vi",
 }
 
 multi_target_uncontrolled_gates = (
@@ -212,8 +212,8 @@ def qiskit_circ_to_ionq_circ(input_circuit, gateset="qis"):
         )
 
         # re-alias certain names
-        if instruction.__class__ in ionq_api_aliases:
-            new_name = ionq_api_aliases.get(instruction.__class__)
+        if instruction_name in ionq_api_aliases:
+            new_name = ionq_api_aliases.get(instruction_name)
             converted["gate"] = new_name
             instruction_name = new_name
 

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -168,7 +168,7 @@ def qiskit_circ_to_ionq_circ(input_circuit, gateset="qis"):
             continue
 
         # serialized identity gate is a no-op
-        if isinstance(instruction, q_gates.i.IGate):
+        if instruction_name == "id":
             continue
 
         # Raise out for instructions we don't support.
@@ -211,9 +211,8 @@ def qiskit_circ_to_ionq_circ(input_circuit, gateset="qis"):
 
         # re-alias certain names
         if instruction_name in ionq_api_aliases:
-            new_name = ionq_api_aliases.get(instruction_name)
-            converted["gate"] = new_name
-            instruction_name = new_name
+            instruction_name = ionq_api_aliases.get(instruction_name)
+            converted["gate"] = instruction_name
 
         # Make sure uncontrolled multi-targets use all qargs.
         if isinstance(instruction, multi_target_uncontrolled_gates):

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -95,8 +95,6 @@ ionq_api_aliases = {  # todo fix alias bug
     "mcphase": "cz",
     "ccx": "cx",  # just one C for all mcx
     "mcx": "cx",  # just one C for all mcx
-    "mcx": "cx",  # just one C for all mcx
-    "mcx": "cx",  # just one C for all mcx
     "mcx_gray": "cx",  # just one C for all mcx
     "tdg": "ti",
     "p": "z",

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join(map(str, (0, 4, 3)))
+VERSION_INFO = ".".join(map(str, (0, 4, 4)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -277,7 +277,7 @@ def test_native_circuit_transpile(simulator_backend):
     circ.append(MSGate(0.2, 0.3, 0.25), [1, 2])
     circ.append(ZZGate(0.4), [0, 2])
 
-    with pytest.raises(Error) as exc_info:
+    with pytest.raises(TranspilerError) as exc_info:
         transpile(circ, backend=simulator_backend)
     assert "Cannot unroll the circuit to the given basis" in exc_info.value.message
 

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -31,7 +31,6 @@ import pytest
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.compiler import transpile
-from qiskit.exceptions import QiskitError
 from qiskit.transpiler.exceptions import TranspilerError
 
 from qiskit_ionq.exceptions import IonQGateError

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -277,7 +277,7 @@ def test_native_circuit_transpile(simulator_backend):
     circ.append(MSGate(0.2, 0.3, 0.25), [1, 2])
     circ.append(ZZGate(0.4), [0, 2])
 
-    with pytest.raises(QiskitError) as exc_info:
+    with pytest.raises(Error) as exc_info:
         transpile(circ, backend=simulator_backend)
     assert "Cannot unroll the circuit to the given basis" in exc_info.value.message
 

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -279,7 +279,7 @@ def test_native_circuit_transpile(simulator_backend):
 
     with pytest.raises(TranspilerError) as exc_info:
         transpile(circ, backend=simulator_backend)
-    assert "Cannot unroll the circuit to the given basis" in exc_info.value.message
+    assert "unable to synthesize" in exc_info.value.message
 
 
 def test_full_native_circuit(simulator_backend):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, lint, docs
+envlist = py38, py39, py310, py311, lint, docs
 
 [gh-actions]
 python =
@@ -7,6 +7,7 @@ python =
   3.8: py38, mypy
   3.9: py39
   3.10: py310
+  3.11: py311
 
 [testenv]
 deps =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

alias bug for gates:

- ccx -> x
- csx -> v
- sdg -> si
- sx -> v
- sxdg -> vi
- tdg -> ti
- toffoli -> x

### Details and comments

passes in python 3.9 but fails with python 3.11

```shell
FAILED test/helpers/test_gate_serialization.py::test_individual_instruction_serialization[ccx-gate_args0-expected_serialization0] - AssertionError: assert [{'gate': 'cx', 'targets': [2], 'controls': [0, 1]}] == [{'gate': 'x', 'targets': [2], 'controls': [0, 1]}]
FAILED test/helpers/test_gate_serialization.py::test_individual_instruction_serialization[csx-gate_args10-expected_serialization10] - AssertionError: assert [{'gate': 'sx', 'targets': [1], 'controls': [0]}] == [{'gate': 'v', 'targets': [1], 'controls': [0]}]
FAILED test/helpers/test_gate_serialization.py::test_individual_instruction_serialization[sdg-gate_args37-expected_serialization37] - AssertionError: assert [{'gate': 'sdg', 'targets': [0]}] == [{'gate': 'si', 'targets': [0]}]
FAILED test/helpers/test_gate_serialization.py::test_individual_instruction_serialization[sx-gate_args39-expected_serialization39] - AssertionError: assert [{'gate': 'sx', 'targets': [0]}] == [{'gate': 'v', 'targets': [0]}]
FAILED test/helpers/test_gate_serialization.py::test_individual_instruction_serialization[sxdg-gate_args40-expected_serialization40] - AssertionError: assert [{'gate': 'sxdg', 'targets': [0]}] == [{'gate': 'vi', 'targets': [0]}]
FAILED test/helpers/test_gate_serialization.py::test_individual_instruction_serialization[tdg-gate_args42-expected_serialization42] - AssertionError: assert [{'gate': 'tdg', 'targets': [0]}] == [{'gate': 'ti', 'targets': [0]}]
FAILED test/helpers/test_gate_serialization.py::test_individual_instruction_serialization[toffoli-gate_args43-expected_serialization43] - AssertionError: assert [{'gate': 'cx', 'targets': [2], 'controls': [0, 1]}] == [{'gate': 'x', 'targets': [2], 'controls': [0, 1]}]
FAILED test/helpers/test_gate_serialization.py::test_multi_control - AssertionError: assert [{'gate': 'cx', 'targets': [2], 'controls': [0, 1]}] == [{'gate': 'x', 'targets': [2], 'controls': [0, 1]}]
FAILED test/helpers/test_qiskit_to_ionq.py::test_native_circuit_transpile - assert 'Cannot unroll the circuit to the given basis' in "HighLevelSynthesis was unable to synthesize Instruction(name='gpi', num_qubits=1, num_clbits=0, par...
```