### PR TITLE
allow shorthand names for ionq backends

### DIFF
--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -99,6 +99,12 @@ class IonQProvider:
             QiskitBackendNotFoundError: if no backend could be found or
                 more than one backend matches the filtering criteria.
         """
+        if not name.startswith("ionq_"):
+            # enable using short names for ionq backends
+            if name == "simulator":
+                name = "ionq_simulator"
+            else:
+                name = "ionq_qpu." + name
         backends = self.backends(name, **kwargs)
         if len(backends) > 1:
             raise QiskitBackendNotFoundError("More than one backend matches criteria.")

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -99,12 +99,7 @@ class IonQProvider:
             QiskitBackendNotFoundError: if no backend could be found or
                 more than one backend matches the filtering criteria.
         """
-        if not name.startswith("ionq_"):
-            # enable using short names for ionq backends
-            if name == "simulator":
-                name = "ionq_simulator"
-            else:
-                name = "ionq_qpu." + name
+        name = "ionq_" + name if not name.startswith("ionq_") else name
         backends = self.backends(name, **kwargs)
         if len(backends) > 1:
             raise QiskitBackendNotFoundError("More than one backend matches criteria.")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

when using the `IonQProvider`, allow for short names / qpu names

### Details and comments

enables this:

```python
provider = IonQProvider()
backend = provider.get_backend("simulator")
# or
backend = provider.get_backend("qpu.aria-1")
```