### PR TITLE
Remove client-side metadata length check

### DIFF
--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -229,32 +229,6 @@ class IonQJobTimeoutError(IonQError, JobTimeoutError):
     """Errors generated from job timeouts"""
 
 
-class IonQMetadataStringError(IonQError, JobError):
-    """Errors generated from metadata strings being too long
-
-    Attributes:
-        string_length: The length of the metadata string that's too long.
-    """
-
-    def __init__(self, string_length):
-        self.string_length = string_length
-        super().__init__(
-            f"attempting to serialize circuit metadata, got length '{string_length}'. "
-            "Must be under 400."
-        )
-        warnings.warn(
-            """
-            This error is a limitation of the IonQ API, not something you did wrong.
-            To submit this circuit we recommend trying the following: shorten the circuit name,
-            Use fewer qubit or cbit registers (i.e. combine them), or give them shorter names.
-            Please file a ticket at support.ionq.co if you repeatedly see this error.
-            """
-        )
-
-    def __str__(self):
-        return f"{self.__class__.__name__}(string_length={self.string_length!r})"
-
-
 __all__ = [
     "IonQError",
     "IonQCredentialsError",
@@ -265,5 +239,4 @@ __all__ = [
     "IonQGateError",
     "IonQMidCircuitMeasurementError",
     "IonQJobTimeoutError",
-    "IonQMetadataStringError",
 ]

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -25,8 +25,6 @@
 # limitations under the License.
 
 """Exceptions for the IonQ Provider."""
-import warnings
-
 import json.decoder as jd
 
 import requests

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -311,7 +311,6 @@ def compress_dict_to_metadata_string(metadata_dict):  # pylint: disable=invalid-
     compressed = gzip.compress(serialized.encode("utf-8"))
     encoded = base64.b64encode(compressed)
     encoded_string = encoded.decode()
-    encoded_string_length = len(encoded_string)
     return encoded_string
 
 

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -294,11 +294,6 @@ def get_register_sizes_and_labels(registers):
     return sizes, labels
 
 
-# slightly goofy workaround to account for the fact that IonQ's "arbitrary" metadata field
-# only takes string KV pairs with value max length 400
-# so we try and pack it down into a more-compressed string format
-# and raise if it's still too long
-# TODO: make this behavior a little nicer (dict metadata) on IonQ side; fix here when we do
 def compress_dict_to_metadata_string(metadata_dict):  # pylint: disable=invalid-name
     """
     Convert a dict to a compact string format (dumped, gzipped, base64 encoded)
@@ -311,17 +306,12 @@ def compress_dict_to_metadata_string(metadata_dict):  # pylint: disable=invalid-
     Returns:
         str: encoded string
 
-    Raises:
-        IonQMetadataStringError: If the base64 encoded `json.dumps`'d dict is
-            greater than 400 characters.
     """
     serialized = json.dumps(metadata_dict)
     compressed = gzip.compress(serialized.encode("utf-8"))
     encoded = base64.b64encode(compressed)
     encoded_string = encoded.decode()
     encoded_string_length = len(encoded_string)
-    if encoded_string_length > 400:  # 400 char is an IonQ API limitation
-        raise exceptions.IonQMetadataStringError(encoded_string_length)
     return encoded_string
 
 


### PR DESCRIPTION
We're raising this limit considerable server-side so we expect both not to hit the limit, and to have a reasonable error message from the API if it does so. 

Either way, the client checking the limit is no longer necessary and impedes further raising the limit in a way that benefits all existing users.
