### PR TITLE
Pass `PauliEvolution` gates to API

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -423,4 +423,4 @@ analyse-fallback-blocks=no
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/sparse_pauli_exp.ipynb
+++ b/sparse_pauli_exp.ipynb
@@ -1,0 +1,200 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit.circuit import QuantumCircuit\n",
+    "from qiskit.circuit.library import PauliEvolutionGate\n",
+    "from qiskit.quantum_info import SparsePauliOp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# build the evolution gate\n",
+    "operator = SparsePauliOp([\"XX\", \"YY\", \"ZZ\"], coeffs = [0.1, 0.2, 0.3])\n",
+    "evo = PauliEvolutionGate(operator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAACuCAYAAADAmD3qAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAZTUlEQVR4nO3deVhU9f4H8PcMu6yyKCgugKCyq4CBmHtpLllqaS5ZZGWiZip1e7qpWXkxb6nZollZvxQp9JaCqXlRRNwwRAlwAQVZZsRhE5Cd+f3BFR1nGAcShjO8X8/D8+j3+z1zPvOg7/me7zlzjkgul8tBRESCJNZ2AURE1HoMcSIiAWOIExEJGEOciEjAGOJERALGECciEjCGOBGRgDHEiYgEjCFORCRgDHEiIgFjiBMRCRhDnIhIwBjiREQCxhAnIhIwhjgRkYAxxImIBIwhTkQkYAxxIiIBY4gTEQkYQ5yISMAY4kREAsYQJyISMIY4EZGAMcSJiASMIU5EJGAMcSIiAWOIExEJGEOciEjAGOJERALGECciEjCGOBGRgDHEiYgEjCFORCRgDHEiIgFjiBMRCRhDnIhIwBjiREQCpq/tAkiRXC5HXWW1tssgolbSNzGCSCRqv/21255II3WV1djpMkfbZRBRK83O/AkGXYzbbX9cTiEiEjCGOBGRgDHEiYgEjCFORCRgDHEiIgFjiBMRCRhDnIhIwBjiREQCxhAnIhIwhjgRkYAxxImIBIwhTkQkYAxxIiIB0/kQl8lkCAsLQ79+/WBsbIxevXph6dKlqKioQEhICEQiEbZs2aLtMomIWkWnb0WbnJyMCRMmQCqVwtTUFO7u7sjPz8fmzZuRmZmJoqIiAICvr692C20JkQjuCyai/9xxMHO0Q1XhbVzffxLJ6yN5H3KiTkhnZ+IymQyTJ0+GVCrF8uXLIZFIkJSUBKlUivDwcMTExCAxMREikQje3t7aLldjAR/MR8Ca+Si5kovT732HrOhTcA95CmN+fAdoxxvRE1HHoLMz8SVLliA3NxehoaHYsGGDQl9YWBh27dqFCxcuwMnJCRYWFlqqsmWs3Bwx8OUJyIo5jWOv3HtPZTcK8NhHIXCaOgzX/3NCixUSUXvTyZl4eno6IiMjYWtri3Xr1qkcM2TIEACAj4+PQvv169cxZcoUmJubo2vXrpg3bx4KCwvbvGZNOD0TDJFYjLRvYhTar+48gto7VXCZ9riWKiMibdHJEI+IiEBDQwNmz54NMzMzlWNMTEwAKIZ4WVkZRo0ahdzcXERERGDbtm2Ij4/HpEmT0NDQ0C61q2Pr2w8N9fWQnb+q0F5fXYuiv7Jg6+uipcqISFt0cjklNjYWADBq1Khmx+Tm5gJQDPFt27YhLy8Px48fR+/evQEAjo6OCAoKwr59+zB16tS2K1oDXbp3RXVRGRpq6pT67kiL0D1gAMQG+mioVe4nIt2kkyGenZ0NAOjTp4/K/rq6OiQkJABQDPHo6GgEBwc3BTgABAYGwtnZGfv37291iPv5+UEqlWo01kAuxioEqOzTMzFCfU2tyr766sZ2fRND1DDEibTGzdUNtaKWH7nb29vj3LlzLd5OJ0O8oqICAFBZWamyPzIyEjKZDObm5nBycmpqT0tLw4wZM5TGe3h4IC0trdX1SKVS5OXlaTTWUKQHdFfdV19ZDQNTS5V9ekYGAIC6yppW1UhEj0a+JB818vp2259Ohri9vT2Ki4uRlJSEwMBAhT6JRIKVK1cCALy9vSG677K84uJiWFlZKb2etbU1Ll++/Lfq0ZSBXAw08yF+52YxLN0cITbUV1pS6WJvjarCUi6lEGlZD4cerZ6Jt4ZOhvjYsWORnp6O8PBwjBs3Dm5ubgCAxMREzJ07FzKZDED7fcmnJYdItXeqsNNljso+WXIGeo70he0gVxScSW9q1zMygLVnX9w8na5yOyJqP1euXoFBF+N2259OXp0SFhYGGxsb5OTkwMPDA15eXnB1dUVAQACcnZ0xevRoAMqXF3bt2hUlJSVKr1dUVARra+v2KF2t67+dhLyhAe4LJiq0u84eC4Muxri297iWKiMibdHJEHd0dER8fDwmTpwIY2NjZGVlwdraGlu3bkVMTAyuXLkCQDnEBw4cqHLtOy0tDQMHDmyX2tUpuXQDl74/iL4TH8Oob1fC9YUx8Fs1DwGrX4T0ZCqu7eUXfYg6G51cTgEaAzk6Olqpvby8HFlZWRCLxfD09FTomzRpEt59913k5ubC0dERAHDmzBlkZmbik08+aZe6H+bs+ztQnnMLbnPGwnHMYFQV3Ub6d7/j/PpIQC7XdnlE1M5Ecnnn+p9/5swZPPbYY+jfvz8uXbqk0Hf79m14eXnB1tYWa9asQVVVFcLCwmBnZ4dTp05BLG77Axd1a+JE1PHNzvyJa+JtKSUlBYDyUgoAWFhYIDY2Fg4ODpg5cyZeeeUVBAUFITo6ul0CnIiopXR2OaU56kIcAFxcXFQuwxARdUSdbnr5sBAnIhKSTjcTv3tfFSIiXdDpZuJERLqEIU5EJGAMcdKanqMHYV5OJCz79dBo/PSzX2L8njWPZN96RgaYfvZLDHpn1iN5PRKmyYfXY9hnb7S4ryPpdGvi1DGI9MTwXzUP1/bGozQjv9Wv475gImpKK5Dx87GWbffaZBhamCL1q31NbT1G+OCJ3f9Exi9xOLHkc6VtBoXNhM+y6UhY8TWu7jwCPRNDPH3k3zC07IJfRyxDVeFthfGWbo6Ycmg9ZBcy8fsz77fbl7GsvZwwMfpjSE+m4o9ZH6ocMy7iPdgHeSBm0rstGluUcr0tS1cwXxKl0biDz66C9FQqxu9ZA/sgj4eOT97wM5L//XPTn0d9txLp2w+gKDVLaVxzfR0JQ5y0ou/kQFi59ULcwo0ab7M3eAnwQA66L5iI8pxbLQpxPWNDeC6cgquRR1FTWtHUnh93AZd/+gP954xDdvQp5By+d+MyGx8XeIVORd7R87i68wgAoL6yBieWfYHxe9fgsfBXFZ57KtITY/jmxWior8eJpVva9du0RSnXcXHTXgxa+Tz6z3sCl388rNDvNncceo70xfn1u1s8tj0dD93UbJ957+4YFDYTVYWlKM1svM3zhU17cGXXEZXj9QwN4L/6RRiYmaDg3L07kuYcPofynFvwXjoNx179t8I26vo6EoY4acWA+eNRlJqF4rRsjbdR9USj1nB+JhhGVmbI/CVOqS9x9Q/oOcIHgetfw82zl1BTUg49IwMM3xyK2ooqJLz1lcL4grOXkL79ADxemwynZ4KbHlTtvXQabH1ccPof21GWfbNVdfoufw6+K57DDofpLd724qY96PWEH/z+ORd5R5NRnlMAADB1tIXfP+dClpyBi5v3tnhsS82XRCnMfFvi2p54le16JoaYuP9jNNTV49hrn6GyoAQAIDl+sdnXCtrwOgwtTHF+/W7kx114YD/H4bX4GZjYWaHyVonGfR0F18Q7IbGhPryWPIunj32Gudd34YVLP2DMD+/A2vPeAzK6OFhjZur3eProp9AzNlTYfvgXS/Fi3s9wGO7V1DZfEoXgjYvgMNwLE6M/xpxrO/H8hW8QsPYl6D/wFWQTOyt0HzoQubFJLar7wTXx+ZIomPXqBvsgD8yXRDX9mDnaqX2dvpMDcedmMYr+Up5Z1v0vqE3sLPHYRyEAgEHvzIKVWy+cff973JEWKW2T9K8IlGbkYeiHITCxs4K1lxO8lz6L/PgUXNpxsEXv8VGR1zcgfsnnEOvrIXjjoqb2YZ8uglhfD/FLPoe8vqHFYzuC4E8XwdqjL/788CdIE/566Pj+856A2+yxuHEoERc+U16iyYs9Dz1DA/SeoPxELXV9HQVDvJMR6eth3K734PvWDNw6dxlnV+1Aypb/wNLNEU/t+xA2Po0PW74jKULCsi/QdUBvBHwwv2n7fjNHw+XZ4Uj54ldI4lMUXtvayxmjvw9DwZ9XkLjmR9w8cwnur0zE6B1vA/c9fKN7oDsAQHY+42+9l+Ohm1BVWIqSq7k4Hrqp6efBtWmF9y8Wo5v/ALX7lpxIwaUfDsP52eHw++dcuC+YiBsHE1XO3AGgvqoGJ5ZugaFFFwR9uhDDN4WivroWCW998bfe399VeiUXSeG7YR/kAfdXJ2HA/PHoMdwL58N3o/RqXqvHapPHwilwmjoM139NQOrW/Q8d382/PwLWvoTSjDzEL1Y+zwEAhSnXUV9VA/tA5fV0dX0dBZdTOpmBL0+AwzBPHJ61FvnH7h1WXtpxCE8f+xT+78/DwWmrADSuCaZtPwD3V55CftxFlFy+gaEfvYyCc5dxPny30mtbu/dB7EvhuHEwEQBw+YdDCFj7EtxfmQinKUG4/lvjc02t3BrvEFmW1bplhruu7YnH4LdnoepWabOH3g8y7WkLAzMTlGWrf+bpn2v/Dz1H+cLzjadRVVSGU2Fb1Y6/lXQVqV/vh1foVABAwoqvUZEr06imtpS6dT96j/fH4HdmQd7QAOnpNKRuU31biZaM1QaH4V4Y8u5sFKVlI+GtLx863qR7V4z8ZgUaauoQG/IJasvuqBzXUFuHCkkhrPo7tqivo+BMvJNxnjYcJVdzUXjxGoyszZt+xIb6yI+7iG4BAxSWT86t/RGFKdcQtOF1jPxmBeS19Ti+cKPKw+vSjLymAL8r5fP/AIDC4aixjQUAoLqkrC3eolr39l2udlx9bR1qyxqf0Vp4MVOj9dC7RwANtXXIO3q+RXWJDfUVfh9G1ubQM2n8PTzYbmhpqvkLy+WI/9+VNiKxWP1J1paMVcHQ0lSpVqBxDfvBdrFhy+aPZo52GPH1MtSWV+Loy+tRV1mtdrzYQB+jtq9Al+5dceLNLSi9kqt2fHVxOYxtVT+/Vl1fR8CZeCdj5eoIfRMjzEr9vtkxRtbmuJNfCKDxZGLcwo2YeuwzdB3QG3FvbER57i2V25VcVf6PUllQguqScpj3uff056ZcuG+JBWj8j2dkZabQVltRhbo7VZq8NY003Xn5gX0/yOfNabDxckJhynX0HOnbdAjfHEvXnhgU9jyK07Nh2a8nhm14HX+88JHGdTlPDUbwplCVfQ/+rspzChAVoPn1y+U3ClAlK23686Ma+6Apf3wCs17dlNq9Fk2F16KpCm0nlm7R+IoiPRNDjPouDIaWpvjvvH9pdKJ46Mch6ObXHxc/34vsmDMP34kIzX9gqevrABjinVBRWjYSV+9otr/6gTVlx7GDIdbXAwDYeDo1XYHRWndf38jKrOnDAgC6+fXH+L2KX+Zp7ZUNmuy7OdZeTvBe8izyjiUj9uX1mPLHBgz9KASSE381Bdz9RGIxgjeFQi6XI/blT9Dv+ZHweXM6XGeNxtUIze7Vk3csGYeeU3zvLjNGot+MEUrt9VU1Gr1mezu+aJPSSfAnf16FjF/ikPnLMYX2kss5Gr9u0IaFsPFyQlJ4BPJiH36E4zZnLPrPGYe8Y8lIWheh0T6MrMyaPZeirq8jYIh3MrevS2FsYwHJib80ml3YeDtjyD9mIy/uAqoLb8Pj9cnIP35R6TItoHGW/yCTblYwsjJD/n2zp+JLNwAAFk4OCpcYFqVlKQXWw2ZdLX2mSUV+IWpuV8DCyUFlv9hQH8M3L0bdnWokLP8K9ZU1SHjrS4zfuwaB4a/iaIjyE568Fk+F3SBXnHnvO5RlSXHh0yj0ftIf/qtfRF7cBYUPquZUFpQ0XSp3V/eAxkcCPngCuaMqSLyssr08+2ar34P7a5Pg8uxw3Dh4Fhc37nnoeLvBrhj6YQjKsm82fgdBg38fYkN9mPawRfYB5Rm7ur6OgmvinUzmL3Ho0r0rPF6brLL//rU//S7GGPHVMtSUliM+dDNOvb0NZTcKMHxzaNPa8v0s+/VE7/H+Cm13T/TdOHi2qU16uvE5pnZD3BTG1pRWQBKfovDzsEP6uooqGKqZVT9I3tCAm2cuwW5wP5X9g1Y8j64DeuPs6h+awrfg7CWkf/s7+jw1FE5ThymM7zqwD3yWzYD0ZCrSvz0AoHFN/MSbX0DfxAjDNryucW2kyD7IA37vzVV7Zcn9TOysMHL7CsgbGnA05BPUPOS8x102nk7QMzLAzdPKz9dV19dRcCbeyaRtj0GPEd7wXzUPDsGekJz4C7Xld2Da0xYOwV6or67FoemrAQCB4Qtg3rc7/njho6ZlhOMLN2LCb2sRvHkxjsxWXPMtSsvG8C1LcGXnf3H7mgQOwzzRd3IgpCdTcf23k03jqgtvQ5LwFxzHDMK5D378W+/nVtJVuM4ajUFhMxvX5BvkyDl8Tu2Jr6z9J9Fr3BDY+vaDLPnepYZ2g13hsXAKco78iYzdissgSet2wXHMYIVlFZG+HoI3haKhrjG071d48RpSvvi1xcsq1MikmxVGbnsLYn09ZMWcRq8n/ZodW5x2A8Xp2Ri5fTlMHWyQfeAMrAb0gtWAXirHV94qVfhiUM8xg1FfU4sbv59VGquur6NgiHcy8rp6HJnzMQbMHw+X6Y/Dd+VzAIBKaTFuJWcg838nm1xmjIDL9BFI2fKrwtKJLDkDSf+KgP/78+Dx2mSFa3WLUq4hcfUODH7nBfSfOw615ZVI//YA/ly3S+mw9vIPhzBy23LYeDuj8OK1Vr+fpHW7YGhlhgHzn4ShpSlEYjGi/Bc2e/IVALL2nYT/6vlwmf54U4jrGRsieFMoassrcXLF10rb1FcpL6v4LJsOGy8nnHrnm6ZvOd6vNcsq1MjSpSeMbRqPCn2WTlM7NnnDzyhOz25afurz1FD0eWpos+OlJ1MVQtxl2uPIOXRO5RVI6vo6ik73oOSOTqgPSp4viUJG5FGlGWlzRGIxpvx3A4pSsxAfurmNq1PmFToVXoufQdTQRRofdpPu6fWkP0Z9uwLRT76tdJMrdX3q8EHJ1CnIGxpw7oMf4TR1GCxde7b7/tO+iUFNaQU8F05p931Tx+G7/Dlk/hKnMqTV9XUkXE4hrck7mowfHZ/Xyr7rq2tbdK016ab9T6xsVV9Hwpk4EZGAcSZOj0RrbpdKRH8fZ+JERALGECciEjCGOBGRgDHEiYgEjCFORCRgDHEiIgFjiBMRCRhDnKgDCFj7Mqaf/RLzJVGw9uir7XJIQBjiRB1AdswpHHj6PZV3QyRSh9/YJOoAbp5O13YJJFCciRMRCRhDnIhIwBjiREQCxhAnIhIwntgk6gAC178KxzFDYNLNCuMi3kNteSX2Bi3WdlkkAAxxog7gVNg2bZdAAsXlFCIiAWOIExEJGEOciEjAGOJERALGECciEjCGOBGRgDHEiYgEjCFORCRgnSLEZTIZwsLC0K9fPxgbG6NXr15YunQpKioqEBISApFIhC1btmi7TCKiFtP5b2wmJydjwoQJkEqlMDU1hbu7O/Lz87F582ZkZmaiqKgIAODr66vdQjXktfgZ2Hg5w8bbGeZ9uqM8pwBRAW9ouywi0hKdnonLZDJMnjwZUqkUy5cvh0QiQVJSEqRSKcLDwxETE4PExESIRCJ4e3tru1yNDHl3NuyHeaIsS4rq4jJtl0NEWqbTIb5kyRLk5uYiNDQUGzZsgLm5eVNfWFgYfHx8UFdXh759+8LCwkKLlWouaugb2O3xEg7PXIs7N4u1XQ4RaZnOhnh6ejoiIyNha2uLdevWqRwzZMgQAICPj09T293QDwgIgJGREUQiUbvUq6nyG3wGIxHdo7MhHhERgYaGBsyePRtmZmYqx5iYmABQDPGMjAzs2bMH9vb28Pf3b5daiYhaS2dDPDY2FgAwatSoZsfk5uYCUAzxxx9/HBKJBPv27cPYsWPbtkgior9JZ69Oyc7OBgD06dNHZX9dXR0SEhIAKIa4WPzoP9f8/PwglUo1GmsgF2MVAh55DUTUPtxc3VAramjxdvb29jh37lyLt9PZEK+oqAAAVFZWquyPjIyETCaDubk5nJyc2rQWqVSKvLw8jcYaivSA7m1aDhG1oXxJPmrk9e22P50NcXt7exQXFyMpKQmBgYEKfRKJBCtXrgQAeHt7t/nJS3t7e43HGsjFQMs/xImog+jh0KPVM/HW0NkQHzt2LNLT0xEeHo5x48bBzc0NAJCYmIi5c+dCJpMBaJ8v+bTkEKn2ThV2usxpw2qIqC1duXoFBl2M221/OntiMywsDDY2NsjJyYGHhwe8vLzg6uqKgIAAODs7Y/To0QAU18OJiIRGZ2fijo6OiI+Px8qVKxEXF4esrCy4u7tj69atWLBgAVxcXAAIL8Sdpz8OM0c7AICxjQXEBvrwfnMaAKA89xauRR3XZnlE1M50NsQBYODAgYiOjlZqLy8vR1ZWFsRiMTw9PbVQWeu5zRoD+yAPhbbBb88CAEhPpjLEiToZnQ7x5qSmpkIul8PNzQ1dunRR6o+KigIApKWlKfy9b9++8PPza79CVTg4bZVW909EHUunDPGUlBQAzS+lzJgxQ+XfX3zxRezYsaNNayMiagmGuApyubw9yyEiajWdvTpFnYeFOBGRUHTKmfjd+6oQEQldp5yJExHpCoY4EZGAMcSJiASMIU5EJGAMcSIiAWOIExEJGEOciEjAGOJERALGECciEjCGOBGRgDHEiYgETCTnLfs6FLlcjrrKam2XQUStpG9i1OYPX78fQ5yISMC4nEJEJGAMcSIiAWOIExEJGEOciEjAGOJERALGECciEjCGOBGRgDHEiYgEjCFORCRgDHEiIgFjiBMRCRhDnIhIwBjiREQCxhAnIhIwhjgRkYAxxImIBIwhTkQkYAxxIiIBY4gTEQkYQ5yISMAY4kREAsYQJyISMIY4EZGAMcSJiASMIU5EJGD/Dwr7/lB/7FGcAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 454.517x200.667 with 1 Axes>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# append it to a circuit\n",
+    "circuit = QuantumCircuit(2)\n",
+    "circuit.append(evo, range(2))\n",
+    "circuit.draw(\"mpl\", style=\"iqp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "instruction.name='PauliEvolution'\n",
+      "instruction.label='exp(-it (XX + YY + ZZ))'\n",
+      "instruction.time=1.0\n",
+      "instruction.operator=SparsePauliOp(['XX', 'YY', 'ZZ'],\n",
+      "              coeffs=[0.1+0.j, 0.2+0.j, 0.3+0.j])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# print the gates' information in the circuit\n",
+    "for instruction, qargs, cargs in circuit.data:\n",
+    "    print(f\"{instruction.name=}\")\n",
+    "    print(f\"{instruction.label=}\")\n",
+    "    print(f\"{instruction.time=}\")\n",
+    "    print(f\"{instruction.operator=}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qiskit_ionq\n",
+    "\n",
+    "# prepare the IonQ backend\n",
+    "provider = qiskit_ionq.IonQProvider()\n",
+    "backend = provider.get_backend(\"simulator\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "instruction_name='PauliEvolution'\n",
+      "{\n",
+      "  \"target\": \"simulator\",\n",
+      "  \"shots\": 1024,\n",
+      "  \"name\": \"circuit-159\",\n",
+      "  \"input\": {\n",
+      "    \"format\": \"ionq.circuit.v0\",\n",
+      "    \"gateset\": \"qis\",\n",
+      "    \"qubits\": 2,\n",
+      "    \"circuit\": [\n",
+      "      {\n",
+      "        \"gate\": \"PAULI\",\n",
+      "        \"targets\": [\n",
+      "          0,\n",
+      "          1\n",
+      "        ],\n",
+      "        \"terms\": [\n",
+      "          \"XX\",\n",
+      "          \"YY\",\n",
+      "          \"ZZ\"\n",
+      "        ],\n",
+      "        \"coefficients\": [\n",
+      "          \"(0.1+0j)\",\n",
+      "          \"(0.2+0j)\",\n",
+      "          \"(0.3+0j)\"\n",
+      "        ],\n",
+      "        \"time\": 1.0,\n",
+      "        \"unitary\": true,\n",
+      "        \"rotation\": 1.0\n",
+      "      }\n",
+      "    ]\n",
+      "  },\n",
+      "  \"registers\": {},\n",
+      "  \"metadata\": {\n",
+      "    \"shots\": \"1024\",\n",
+      "    \"sampler_seed\": \"None\",\n",
+      "    \"qiskit_header\": \"H4sIANu+wmUC/1WLQQqDMBBFryKzbosKXbRXkTAkYbCBiWkSs1Dp3ZtRENzNvPf+Bp58SAtmDnOGd9PeGhg5GM34/ehMgh4CJ4zFuL3p5dVeHFiXbHHzvXu+oGKbaMTsVpJuUEK4rpC1IT5ZvFQDxDrt1W7KtT5cW9VxdUr9/nLahJK0AAAA\"\n",
+      "  },\n",
+      "  \"noise\": {\n",
+      "    \"model\": \"ideal\",\n",
+      "    \"seed\": null\n",
+      "  }\n",
+      "}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/churchill/GitHub/qiskit-ionq/qiskit_ionq/ionq_backend.py:377: UserWarning: Circuit circuit-159 is not measuring any qubits\n",
+      "  return super().run(circuit, **kwargs)\n",
+      "/Users/churchill/GitHub/qiskit-ionq/qiskit_ionq/helpers.py:477: UserWarning: Unable to encode (0.1+0j) using <lambda>: super(): no arguments\n",
+      "  warnings.warn(\n",
+      "/Users/churchill/GitHub/qiskit-ionq/qiskit_ionq/helpers.py:477: UserWarning: Unable to encode (0.2+0j) using <lambda>: super(): no arguments\n",
+      "  warnings.warn(\n",
+      "/Users/churchill/GitHub/qiskit-ionq/qiskit_ionq/helpers.py:477: UserWarning: Unable to encode (0.3+0j) using <lambda>: super(): no arguments\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "ename": "IonQJobFailureError",
+     "evalue": "IonQJobFailureError('Unable to retreive result for job 67f13814-3f2b-437d-8cf8-1f087abed851. Failure from IonQ API \"PreflightError: illegal gate: \"PAULI\"\"')",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIonQJobFailureError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[6], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m job \u001b[38;5;241m=\u001b[39m backend\u001b[38;5;241m.\u001b[39mrun(circuit)\n\u001b[0;32m----> 2\u001b[0m result \u001b[38;5;241m=\u001b[39m \u001b[43mjob\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresult\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28mprint\u001b[39m(result\u001b[38;5;241m.\u001b[39mget_counts())\n",
+      "File \u001b[0;32m~/GitHub/qiskit-ionq/qiskit_ionq/ionq_job.py:286\u001b[0m, in \u001b[0;36mIonQJob.result\u001b[0;34m(self, sharpen, extra_query_params, **kwargs)\u001b[0m\n\u001b[1;32m    284\u001b[0m \u001b[38;5;66;03m# Wait for the job to complete.\u001b[39;00m\n\u001b[1;32m    285\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 286\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mwait_for_final_state\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    287\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m JobTimeoutError \u001b[38;5;28;01mas\u001b[39;00m ex:\n\u001b[1;32m    288\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m exceptions\u001b[38;5;241m.\u001b[39mIonQJobTimeoutError(\n\u001b[1;32m    289\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTimed out waiting for job to complete.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    290\u001b[0m     ) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mex\u001b[39;00m\n",
+      "File \u001b[0;32m/opt/homebrew/lib/python3.11/site-packages/qiskit/providers/job.py:122\u001b[0m, in \u001b[0;36mJobV1.wait_for_final_state\u001b[0;34m(self, timeout, wait, callback)\u001b[0m\n\u001b[1;32m    120\u001b[0m         callback(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjob_id(), status, \u001b[38;5;28mself\u001b[39m)\n\u001b[1;32m    121\u001b[0m     time\u001b[38;5;241m.\u001b[39msleep(wait)\n\u001b[0;32m--> 122\u001b[0m     status \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstatus\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    123\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m\n",
+      "File \u001b[0;32m~/GitHub/qiskit-ionq/qiskit_ionq/ionq_job.py:367\u001b[0m, in \u001b[0;36mIonQJob.status\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    362\u001b[0m     failure_message \u001b[38;5;241m=\u001b[39m failure\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124merror\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    363\u001b[0m     error_message \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    364\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnable to retreive result for job \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjob_id()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m. \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    365\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mFailure from IonQ API \u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfailure_type\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfailure_message\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    366\u001b[0m     )\n\u001b[0;32m--> 367\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m exceptions\u001b[38;5;241m.\u001b[39mIonQJobFailureError(error_message)\n\u001b[1;32m    369\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_status \u001b[38;5;241m==\u001b[39m jobstatus\u001b[38;5;241m.\u001b[39mJobStatus\u001b[38;5;241m.\u001b[39mCANCELLED:\n\u001b[1;32m    370\u001b[0m     error_message \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    371\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mUnable to retreive result for job \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjob_id()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m. Job was cancelled\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    372\u001b[0m     )\n",
+      "\u001b[0;31mIonQJobFailureError\u001b[0m: IonQJobFailureError('Unable to retreive result for job 67f13814-3f2b-437d-8cf8-1f087abed851. Failure from IonQ API \"PreflightError: illegal gate: \"PAULI\"\"')"
+     ]
+    }
+   ],
+   "source": [
+    "job = backend.run(circuit)\n",
+    "result = job.result()\n",
+    "\n",
+    "print(result.get_counts())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

Enables sending `PauliEvolution` to API instead of unrolled Pauli gates.

### Details and comments

Gates have the format:

```json
{
  "gate": "PAULI",
  "targets": [
    0,
    1
  ],
  "terms": [
    "XX",
    "YY",
    "ZZ"
  ],
  "coefficients": [
    "(0.1+0j)",
    "(0.2+0j)",
    "(0.3+0j)"
  ],
  "time": 1.0,
  "unitary": true,
  "rotation": 1.0
}
```