### PR TITLE
Change qiskit dependency to allow 0.4+

### DIFF
--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join(map(str, (0, 5, 0, "dev0")))
+VERSION_INFO = ".".join(map(str, (0, 5, 0, "dev1")))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+qiskit>=0.4.0
 decorator>=5.1.0
-qiskit>=1.0.0
 requests>=2.24.0
 retry>=0.9.0
 importlib-metadata>=4.11.4


### PR DESCRIPTION
Qiskit 1.0 works, but there is nothing preventing older library versions, and we'd prefer to support both for some period to allow for library compatibility flexibility