### PR TITLE
add backend cancel job methods and save metadata

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,13 +42,14 @@
 
 """Sphinx doc build configuration."""
 import qiskit_sphinx_theme
+from qiskit_ionq.version import VERSION_INFO
 
 # -- Project information -----------------------------------------------------
 
 project = "Qiskit IonQ Provider"  # pylint: disable=invalid-name
 copyright = "2020, IonQ, Inc."  # pylint: disable=invalid-name,redefined-builtin
 author = "IonQ, Inc."  # pylint: disable=invalid-name
-release = "0.0.1"  # pylint: disable=invalid-name
+release = VERSION_INFO  # pylint: disable=invalid-name
 
 
 # -- General configuration ---------------------------------------------------
@@ -57,15 +58,15 @@ release = "0.0.1"  # pylint: disable=invalid-name
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.extlinks',
-    'jupyter_sphinx',
-    'sphinx_panels',
-    'qiskit_sphinx_theme',
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.extlinks",
+    "jupyter_sphinx",
+    "sphinx_panels",
+    "qiskit_sphinx_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -74,7 +75,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', '**.ipynb_checkpoints']
+exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -88,10 +89,10 @@ autosummary_generate = True
 autosummary_generate_overwrite = False
 
 autodoc_default_options = {
-    'inherited-members': None,
+    "inherited-members": None,
 }
 
-autoclass_content = 'both'
+autoclass_content = "both"
 #
 # Sphinx doc mappings
 intersphinx_mapping = {

--- a/qiskit_ionq/__init__.py
+++ b/qiskit_ionq/__init__.py
@@ -34,7 +34,7 @@ from .constants import ErrorMitigation
 
 # warn if qiskit is not installed
 try:
-    import qiskit  # pylint: disable=unused-import
+    from qiskit.version import get_version_info  # pylint: disable=unused-import
 except ImportError:
     warnings.warn(
         "Qiskit is not installed. Please install the latest version of Qiskit."

--- a/qiskit_ionq/__init__.py
+++ b/qiskit_ionq/__init__.py
@@ -26,7 +26,16 @@
 
 """Provider for IonQ backends"""
 
+import warnings
 from .ionq_provider import IonQProvider
 from .version import __version__
 from .ionq_gates import GPIGate, GPI2Gate, MSGate, ZZGate
 from .constants import ErrorMitigation
+
+# warn if qiskit is not installed
+try:
+    import qiskit  # pylint: disable=unused-import
+except ImportError:
+    warnings.warn(
+        "Qiskit is not installed. Please install the latest version of Qiskit."
+    )

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -261,8 +261,15 @@ class IonQBackend(Backend):
 
     def retrieve_jobs(self, job_ids):
         """get a list of jobs from a specific backend, job id"""
-
         return [ionq_job.IonQJob(self, job_id, self.client) for job_id in job_ids]
+
+    def cancel_job(self, job_id):
+        """cancels a job from a specific backend, by job id."""
+        return self.client.cancel_job(job_id)
+
+    def cancel_jobs(self, job_ids):
+        """cancels a list of jobs from a specific backend, job id"""
+        return [self.client.cancel_job(job_id) for job_id in job_ids]
 
     def has_valid_mapping(self, circuit) -> bool:
         """checks if the circuit has at least one

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -75,7 +75,7 @@ class IonQClient:
         Returns:
             str: A URL to use for an API call.
         """
-        return "/".join([self._url] + list(parts))
+        return f"{self._url}/{'/'.join(parts)}"
 
     def _get_with_retry(self, req_path, params=None, headers=None, timeout=30):
         """Make a GET request with retry logic and exception handling.
@@ -173,6 +173,17 @@ class IonQClient:
         res = requests.put(req_path, headers=self.api_headers, timeout=30)
         exceptions.IonQAPIError.raise_for_status(res)
         return res.json()
+
+    def cancel_jobs(self, job_ids: list):
+        """Cancel multiple jobs at once.
+
+        Args:
+            job_ids (list): A list of job IDs to cancel.
+
+        Returns:
+            list: A list of :meth:`cancel_job <cancel_job>` responses.
+        """
+        return [self.cancel_job(job_id) for job_id in job_ids]
 
     @retry(exceptions=IonQRetriableError, tries=3)
     def delete_job(self, job_id: str):

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -87,7 +87,7 @@ class IonQProvider:
             ]
         )
 
-    def get_backend(self, name=None, gateset="qis", **kwargs):
+    def get_backend(self, name: str = None, gateset="qis", **kwargs):
         """Return a single backend matching the specified filtering.
         Args:
             name (str): name of the backend.

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join(map(str, (0, 5, 0)))
+VERSION_INFO = ".".join(map(str, (0, 5, 0, "dev2")))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join(map(str, (0, 5, 0, "dev1")))
+VERSION_INFO = ".".join(map(str, (0, 5, 0)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-qiskit >= 1.0.0
+qiskit>=1.0.0
 retry>=0.9.0
 Sphinx>=4.5.0
 sphinx-tabs>=1.1.11

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
+qiskit >= 1.0.0
 retry>=0.9.0
 Sphinx>=4.5.0
 sphinx-tabs>=1.1.11

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+qiskit>=1.0.0
 pytest
 requests-mock>=1.8.0
 pytest-cov==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.4.0
+qiskit>=0.46.0
 decorator>=5.1.0
 requests>=2.24.0
 retry>=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-qiskit>=0.46.0
 decorator>=5.1.0
 requests>=2.24.0
 retry>=0.9.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

```python
# Print all metadata
print(job._metadata)
```

```python
# Cancel jobs with the backend
backend.cancel_job('9a36b191-d8be-4b77-abcc-ec1ef0ac15d2')
backend.cancel_jobs(['6fb62d08-4e55-4fbd-8874-b01453290730', '37635b2b-994b-42f4-8d65-c4133328f95d'])
```

plus remove qiskit dep (warn if not installed)