### PR TITLE
Correct MS gate matrix

### DIFF
--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -108,8 +108,8 @@ class MSGate(Gate):
        MS(\phi_0, _\phi_1, \theta) q_0, q_1 =
             \begin{pmatrix}
                 cos{\theta*\pi} & 0 & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1)}*sin{\theta*\pi} \\
-                0 & cos{\theta*\pi} & -i*e^{-i*2*\pi(\phi_0-\phi_1)}*sin{\theta*\pi} & 0 \\
-                0 & -i*e^{i*2*\pi(\phi_0-\phi_1)}*sin(\theta*\pi) & cos{\theta*\pi} & 0 \\
+                0 & cos{\theta*\pi} & -i*e^{i*2*\pi(\phi_0-\phi_1)}*sin{\theta*\pi} & 0 \\
+                0 & -i*e^{-i*2*\pi(\phi_0-\phi_1)}*sin(\theta*\pi) & cos{\theta*\pi} & 0 \\
                 -i*e^{i*2*\pi(\phi_0+\phi_1)}*sin{\theta*\pi} & 0 & 0 & cos{\theta*\pi}
             \end{pmatrix}
     """
@@ -140,8 +140,8 @@ class MSGate(Gate):
         return numpy.array(
             [
                 [diag, 0, 0, sin * -1j * cmath.exp(-1j * 2 * math.pi * (phi0 + phi1))],
-                [0, diag, sin * -1j * cmath.exp(-1j * 2 * math.pi * (phi0 - phi1)), 0],
-                [0, sin * -1j * cmath.exp(1j * 2 * math.pi * (phi0 - phi1)), diag, 0],
+                [0, diag, sin * -1j * cmath.exp(1j * 2 * math.pi * (phi0 - phi1)), 0],
+                [0, sin * -1j * cmath.exp(-1j * 2 * math.pi * (phi0 - phi1)), diag, 0],
                 [sin * -1j * cmath.exp(1j * 2 * math.pi * (phi0 + phi1)), 0, 0, diag],
             ],
             dtype=dtype,

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -105,12 +105,12 @@ class MSGate(Gate):
 
     .. math::
 
-       MS(\phi_0, _\phi_1, \theta) q_0, q_1 =
+       MS(\phi_0, \phi_1, \theta) =
             \begin{pmatrix}
-                cos{\theta*\pi} & 0 & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1)}*sin{\theta*\pi} \\
-                0 & cos{\theta*\pi} & -i*e^{i*2*\pi(\phi_0-\phi_1)}*sin{\theta*\pi} & 0 \\
-                0 & -i*e^{-i*2*\pi(\phi_0-\phi_1)}*sin(\theta*\pi) & cos{\theta*\pi} & 0 \\
-                -i*e^{i*2*\pi(\phi_0+\phi_1)}*sin{\theta*\pi} & 0 & 0 & cos{\theta*\pi}
+                cos(\theta*\pi) & 0 & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1)}*sin(\theta*\pi) \\
+                0 & cos(\theta*\pi) & -i*e^{i*2*\pi(\phi_0-\phi_1)}*sin(\theta*\pi) & 0 \\
+                0 & -i*e^{-i*2*\pi(\phi_0-\phi_1)}*sin(\theta*\pi) & cos(\theta*\pi) & 0 \\
+                -i*e^{i*2*\pi(\phi_0+\phi_1)}*sin(\theta*\pi) & 0 & 0 & cos(\theta*\pi)
             \end{pmatrix}
     """
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

Fixes #162 ; current matrix is big-endian, while Qiskit is little-endian.

### Details and comments
