### PR TITLE
add method to display child progress

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -423,4 +423,4 @@ analyse-fallback-blocks=no
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/README.md
+++ b/README.md
@@ -17,14 +17,6 @@ The IonQ Provider uses IonQ's REST API, and using the provider requires an API a
 
 ## Installation
 
-> :information_source: **The Qiskit IonQ Provider requires** `qiskit-terra>=0.17.4`!
->
-> To ensure you are on the latest version, run:
->
-> ```bash
-> pip install -U "qiskit-terra>=0.17.4"
-> ```
-
 You can install the provider using pip:
 
 ```bash

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -473,7 +473,7 @@ class SafeEncoder(json.JSONEncoder):
         for func in funcs:
             try:
                 return func()
-            except Exception as exception:
+            except Exception as exception:  # pylint: disable=broad-except
                 warnings.warn(
                     f"Unable to encode {o} using {func.__name__}: {exception}"
                 )

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -366,6 +366,65 @@ class IonQJob(JobV1):
 
         return self._status
 
+    def children_status(self):
+        """Retrieve the status of the children
+
+        Raises:
+            IonQJobError: If the IonQ job status was unknown or otherwise
+                unmappable to a qiskit job status.
+            IonQJobFailureError: If the job fails
+            IonQJobStateError: If the job was cancelled
+
+        Returns:
+            dict: A dictionary containing the detailed status of the children.
+        """
+        response = self._client.retrieve_job(self._job_id)
+        child_ids = response.get("children", [])
+        child_statuses = []
+
+        for child_id in child_ids:
+            response = self._client.retrieve_job(child_id)
+            api_response_status = response.get("status")
+
+            # Map API status to JobStatus enum
+            try:
+                status_enum = constants.APIJobStatus(api_response_status)
+            except ValueError as ex:
+                raise exceptions.IonQJobError(
+                    f"Unknown job status {api_response_status}"
+                ) from ex
+
+            try:
+                status_enum = constants.JobStatusMap[status_enum.name]
+            except ValueError as ex:
+                raise exceptions.IonQJobError(
+                    f"Job status {status_enum} has no qiskit status mapping!"
+                ) from ex
+
+            try:
+                qiskit_status = jobstatus.JobStatus[status_enum.value]
+            except KeyError as ex:
+                raise exceptions.IonQJobError(
+                    f"Qiskit has no JobStatus named '{status_enum}'"
+                ) from ex
+
+            child_statuses.append(qiskit_status)
+
+        total = len(child_statuses)
+        completed = child_statuses.count(jobstatus.JobStatus.DONE)
+        failed = child_statuses.count(jobstatus.JobStatus.ERROR)
+        percentage_complete = completed / total if total else 0
+
+        status_summary = {
+            "total": total,
+            "completed": completed,
+            "failed": failed,
+            "percentage_complete": percentage_complete,
+            "statuses": child_statuses,
+        }
+
+        return status_summary
+
     def _format_result(self, data):
         """Translate IonQ's result format into a qiskit Result instance.
 

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, patch
-VERSION_INFO = ".".join(map(str, (0, 5, 1)))
+VERSION_INFO = ".".join(map(str, (0, 5, 2)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.24.0
 retry>=0.9.0
 importlib-metadata>=4.11.4
 python-dotenv>=1.0.1
+qiskit>=0.46.0,<1.1.0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -74,7 +74,7 @@ class MockBackend(ionq_backend.IonQBackend):
 
 
 def dummy_job_response(
-    job_id, target="mock_backend", status="completed", job_settings=None
+    job_id, target="mock_backend", status="completed", job_settings=None, children=None
 ):
     """A dummy response payload for `job_id`.
 
@@ -83,6 +83,7 @@ def dummy_job_response(
         target (str): Backend target string.
         status (str): A provided status string.
         job_settings (dict): Settings provided to the API.
+        children (list): A list of child job IDs.
 
     Returns:
         dict: A json response dict.
@@ -99,7 +100,7 @@ def dummy_job_response(
             "global_phase": 0,
         }
     )
-    return {
+    response = {
         "status": status,
         "predicted_execution_time": 4,
         "metadata": {
@@ -121,6 +122,11 @@ def dummy_job_response(
         "settings": (job_settings or {}),
         "name": "test_name",
     }
+
+    if children is not None:
+        response["children"] = children
+
+    return response
 
 
 def dummy_failed_job(job_id):  # pylint: disable=differing-param-doc,differing-type-doc

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -140,7 +140,9 @@ def test_run(mock_backend, requests_mock):
     requests_mock.post(path, json=dummy_response, status_code=200)
 
     # Run a dummy circuit.
-    job = mock_backend.run(QuantumCircuit(1, 1))
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    job = mock_backend.run(qc)
 
     assert isinstance(job, ionq_job.IonQJob)
     assert job.job_id() == "fake_job"
@@ -160,7 +162,9 @@ def test_run_single_element_list(mock_backend, requests_mock):
     requests_mock.post(path, json=dummy_response, status_code=200)
 
     # Run a dummy circuit.
-    job = mock_backend.run([QuantumCircuit(1, 1)])
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    job = mock_backend.run([qc])
 
     assert isinstance(job, ionq_job.IonQJob)
     assert job.job_id() == "fake_job"
@@ -180,8 +184,10 @@ def test_run_extras(mock_backend, requests_mock):
     requests_mock.post(path, json=dummy_response, status_code=200)
 
     # Run a dummy circuit.
+    qc = QuantumCircuit(1, metadata={"experiment": "abc123"})
+    qc.measure_all()
     job = mock_backend.run(
-        QuantumCircuit(1, 1, metadata={"experiment": "abc123"}),
+        qc,
         extra_query_params={
             "error_mitigation": {"debias": True},
         },
@@ -241,8 +247,10 @@ def test_multiexp_job(mock_backend, requests_mock):
     # Run a dummy multi-experiment job.
     qc1 = QuantumCircuit(1, 1)
     qc1.h(0)
+    qc1.measure(0, 0)
     qc2 = QuantumCircuit(1, 1)
     qc2.x(0)
+    qc2.measure(0, 0)
     job = mock_backend.run([qc1, qc2])
 
     # Verify json payload
@@ -266,11 +274,11 @@ def test_multiexp_job(mock_backend, requests_mock):
             "circuits": [
                 {
                     "circuit": [{"gate": "h", "targets": [0]}],
-                    "registers": {"meas_mapped": [None]},
+                    "registers": {"meas_mapped": [0]},
                 },
                 {
                     "circuit": [{"gate": "x", "targets": [0]}],
-                    "registers": {"meas_mapped": [None]},
+                    "registers": {"meas_mapped": [0]},
                 },
             ],
         },

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -693,21 +693,36 @@ def test_status_with_detailed(mock_backend, requests_mock):
 
     Args:
         mock_backend (MockBackend): A fake/mock IonQBackend.
-        requests_mock (:class:`request_mock.Mocker`): A requests mocker.
+        requests_mock (:class:`requests_mock.Mocker`): A requests mocker.
     """
     job_id = "test_id"
-    child_job_id = "child_test_id"
-    job_response = conftest.dummy_job_response(
-        job_id, status="completed", children=[child_job_id]
-    )
-    child_job_response = conftest.dummy_job_response(child_job_id, status="completed")
-    client = mock_backend.client
+    child_job_id_1 = "child_test_id_1"
+    child_job_id_2 = "child_test_id_2"
 
-    # Mock the job response API calls.
-    path = client.make_path("jobs", job_id)
-    child_path = client.make_path("jobs", child_job_id)
-    requests_mock.get(path, status_code=200, json=job_response)
-    requests_mock.get(child_path, status_code=200, json=child_job_response)
+    # Create dummy job responses
+    job_response = conftest.dummy_job_response(
+        job_id, status="completed", children=[child_job_id_1, child_job_id_2]
+    )
+    child_job_1_response = conftest.dummy_job_response(
+        child_job_id_1, status="completed"
+    )
+    child_job_2_response = conftest.dummy_job_response(child_job_id_2, status="running")
+
+    # Mock the job response API calls
+    client = mock_backend.client
+    requests_mock.get(
+        client.make_path("jobs", job_id), status_code=200, json=job_response
+    )
+    requests_mock.get(
+        client.make_path("jobs", child_job_id_1),
+        status_code=200,
+        json=child_job_1_response,
+    )
+    requests_mock.get(
+        client.make_path("jobs", child_job_id_2),
+        status_code=200,
+        json=child_job_2_response,
+    )
 
     # Create a job ref (this will call .status() to fetch our mock above)
     job = ionq_job.IonQJob(mock_backend, job_id)
@@ -715,12 +730,14 @@ def test_status_with_detailed(mock_backend, requests_mock):
     # Call status with detailed=True
     detailed_status = job.status(detailed=True)
 
+    # Expected detailed status
     expected_detailed_status = {
-        "total": 1,
+        "total": 2,
         "completed": 1,
         "failed": 0,
-        "percentage_complete": 1.0,
-        "statuses": [jobstatus.JobStatus.DONE],
+        "percentage_complete": 0.5,
+        "statuses": [jobstatus.JobStatus.DONE, jobstatus.JobStatus.RUNNING],
     }
 
+    # Assert the detailed status
     assert detailed_status == expected_detailed_status


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

creates `children_status` method for reporting child statuses:

```python
status = job.status(detailed=True)
print(status)
```

```python
{'total': 2, 'completed': 0, 'failed': 0, 'percentage_complete': 0.0, 'statuses': [<JobStatus.QUEUED: 'job is queued'>, <JobStatus.QUEUED: 'job is queued'>]}
{'total': 2, 'completed': 1, 'failed': 0, 'percentage_complete': 0.5, 'statuses': [<JobStatus.QUEUED: 'job is queued'>, <JobStatus.DONE: 'job has successfully run'>]}
{'total': 2, 'completed': 2, 'failed': 0, 'percentage_complete': 1.0, 'statuses': [<JobStatus.DONE: 'job has successfully run'>, <JobStatus.DONE: 'job has successfully run'>]}
```

### Details and comments
