### PR TITLE
Remove qiskit > 1.0.0 requirement

### DIFF
--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, patch
-VERSION_INFO = ".".join(map(str, (0, 5, 3)))
+VERSION_INFO = ".".join(map(str, (0, 5, 4)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ requests>=2.24.0
 retry>=0.9.0
 importlib-metadata>=4.11.4
 python-dotenv>=1.0.1
-qiskit>=1.0.0
+qiskit


### PR DESCRIPTION
As noted in qiskit's docs, it's potentially problematic to upgrade a pre-existing python environment to qiskit 1.0.0.

Given that we don't require any 1.0.0 functionality (i.e, are currently cross-compatible), we can relax the versioning requirement and just require qiskit.