### PR TITLE
allow setting multicircuit names from run method

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -411,7 +411,7 @@ def qiskit_to_ionq(
     ionq_json = {
         "target": target,
         "shots": passed_args.get("shots"),
-        "name": ", ".join([c.name for c in circuit]),
+        "name": passed_args.get("name") or ", ".join([c.name for c in circuit]),
         "input": {
             "format": "ionq.circuit.v0",
             "gateset": backend.gateset(),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

can do:

```python
multi_result = backend.run([qc_1, qc_2], name="multi-circuit").result().get_counts()
```

### Details and comments

when running many jobs, concatenating child circuit names wont scale. this lets you set a short name