### PR TITLE
fix default qubit warning for simulator

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -544,6 +544,8 @@ def get_n_qubits(backend: str, _fallback=100) -> int:
     Returns:
         int: The number of qubits for the backend.
     """
+    if backend == "simulator":
+        return 29
     creds = resolve_credentials()
     url = creds.get("url")
     token = creds.get("token")

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -552,15 +552,10 @@ def get_n_qubits(backend: str, fallback: int = 100) -> int:
     creds = resolve_credentials()
     url = creds.get("url")
 
-    target = (
-        backend.split("ionq_")[-1] if backend.startswith("ionq_qpu.") else backend
-    )
+    target = backend.split("ionq_")[-1] if backend.startswith("ionq_qpu.") else backend
 
     try:
-        response = requests.get(
-            url=f"{url}/backends",
-            timeout=5,
-        )
+        response = requests.get(url=f"{url}/backends", timeout=5)
         response.raise_for_status()  # Ensure we catch any HTTP errors
         return next(
             (item["qubits"] for item in response.json() if item["backend"] == target),

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -38,7 +38,6 @@ import platform
 import warnings
 import os
 from typing import Literal, Any
-from functools import lru_cache
 import requests
 from dotenv import dotenv_values
 
@@ -500,7 +499,6 @@ class SafeEncoder(json.JSONEncoder):
         return "unknown"
 
 
-@lru_cache(maxsize=1)
 def resolve_credentials(token: str | None = None, url: str | None = None) -> dict:
     """Resolve credentials for use in IonQ API calls.
 
@@ -517,7 +515,6 @@ def resolve_credentials(token: str | None = None, url: str | None = None) -> dic
     Returns:
         dict[str]: A dict with "token" and "url" keys, for use by a client.
     """
-    # Cache dotenv and environment variable lookups
     env_values = dotenv_values()
     env_token = (
         env_values.get("QISKIT_IONQ_API_TOKEN")

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -539,12 +539,12 @@ def resolve_credentials(token: str | None = None, url: str | None = None) -> dic
     }
 
 
-def get_n_qubits(backend: str, _fallback: int = 100) -> int:
+def get_n_qubits(backend: str, fallback: int = 100) -> int:
     """Get the number of qubits for a given backend.
 
     Args:
         backend (str): The name of the backend.
-        _fallback (int): Fallback number of qubits if API call fails.
+        fallback (int): Fallback number of qubits if API call fails.
 
     Returns:
         int: The number of qubits for the backend.
@@ -569,13 +569,13 @@ def get_n_qubits(backend: str, _fallback: int = 100) -> int:
         )
         response.raise_for_status()  # Ensure we catch any HTTP errors
         return response.json().get(
-            "qubits", _fallback
-        )  # Default to _fallback if "qubits" key is missing
+            "qubits", fallback
+        )  # Default to fallback if "qubits" key is missing
     except Exception as exception:  # pylint: disable=broad-except
         warnings.warn(
-            f"Unable to get qubit count for {backend}: {exception}. Defaulting to {_fallback}."
+            f"Unable to get qubit count for {backend}: {exception}. Defaulting to {fallback}."
         )
-        return _fallback
+        return fallback
 
 
 __all__ = [

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -571,9 +571,9 @@ def get_n_qubits(backend: str, _fallback: int = 100) -> int:
         return response.json().get(
             "qubits", _fallback
         )  # Default to _fallback if "qubits" key is missing
-    except requests.RequestException as e:
+    except Exception as exception:  # pylint: disable=broad-except
         warnings.warn(
-            f"Unable to get qubit count for {backend}: {e}. Defaulting to {_fallback}."
+            f"Unable to get qubit count for {backend}: {exception}. Defaulting to {_fallback}."
         )
         return _fallback
 

--- a/test/helpers/test_helpers.py
+++ b/test/helpers/test_helpers.py
@@ -55,18 +55,23 @@ def test_get_n_qubits_success():
     """Test get_n_qubits returns correct number of qubits and checks correct URL."""
     with patch("requests.get") as mock_get:
         mock_response = MagicMock()
-        mock_response.json.return_value = {"qubits": 11}
+        mock_response.json.return_value = [
+            {
+                "backend": "qpu.aria-1",
+                "status": "unavailable",
+                "qubits": 25,
+                "average_queue_time": 722980302,
+                "last_updated": 1729699872,
+                "characterization_url": "/characterizations/9d699f61-d894-49b3-94c0-fd8173b32c27",
+                "degraded": False,
+            }
+        ]
         mock_get.return_value = mock_response
 
         backend = "ionq_qpu.aria-1"
         result = get_n_qubits(backend)
 
-        expected_url = (
-            "https://api.ionq.co/v0.3/characterizations/backends/aria-1/current"
-        )
-
-        # Create a regular expression to match the Authorization header with an apiKey
-        expected_headers = {"Authorization": re.compile(r"apiKey\s+\S+")}
+        expected_url = "https://api.ionq.co/v0.3/backends"
 
         # Check the arguments of the last call to `requests.get`
         mock_get.assert_called()
@@ -75,15 +80,7 @@ def test_get_n_qubits_success():
             kwargs["url"] == expected_url
         ), f"Expected URL {expected_url}, but got {kwargs['url']}"
 
-        # Assert that the headers contain the apiKey in the expected format
-        assert re.match(
-            expected_headers["Authorization"], kwargs["headers"]["Authorization"]
-        ), (
-            f"Expected headers to match {expected_headers['Authorization'].pattern}, "
-            f"but got {kwargs['headers']['Authorization']}"
-        )
-
-        assert result == 11, f"Expected 11 qubits, but got {result}"
+        assert result == 25, f"Expected 25 qubits, but got {result}"
 
 
 def test_get_n_qubits_fallback():
@@ -92,12 +89,7 @@ def test_get_n_qubits_fallback():
         backend = "aria-1"
         result = get_n_qubits(backend)
 
-        expected_url = (
-            "https://api.ionq.co/v0.3/characterizations/backends/aria-1/current"
-        )
-
-        # Create a regular expression to match the Authorization header with an apiKey
-        expected_headers = {"Authorization": re.compile(r"apiKey\s+\S+")}
+        expected_url = "https://api.ionq.co/v0.3/backends"
 
         # Check the arguments of the last call to `requests.get`
         mock_get.assert_called()
@@ -105,13 +97,5 @@ def test_get_n_qubits_fallback():
         assert (
             kwargs["url"] == expected_url
         ), f"Expected URL {expected_url}, but got {kwargs['url']}"
-
-        # Assert that the headers contain the apiKey in the expected format
-        assert re.match(
-            expected_headers["Authorization"], kwargs["headers"]["Authorization"]
-        ), (
-            f"Expected headers to match {expected_headers['Authorization'].pattern}, "
-            f"but got {kwargs['headers']['Authorization']}"
-        )
 
         assert result == 100, f"Expected fallback of 100 qubits, but got {result}"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

the simulator doesn't have accessible qubit defaults, so we need to manually add this

### Details and comments

prevents a warning from the backend initialization