### PR TITLE
Fix bug regarding serializing custom exceptions which occurs in multiprocessing context

### DIFF
--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -168,6 +168,18 @@ class IonQAPIError(IonQError):
             f"error_type={self.error_type!r})"
         )
 
+    def __getstate__(self) -> object:
+        return (
+            self.message,
+            self.status_code,
+            self.headers,
+            self.body,
+            self.error_type,
+        )
+
+    def __setstate__(self, state: tuple[object, ...]) -> None:
+        self.message, self.status_code, self.headers, self.body, self.error_type = state
+
 
 class IonQBackendError(IonQError):
     """Errors generated from improper usage of IonQBackend objects."""

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -98,6 +98,13 @@ class IonQAPIError(IonQError):
         error_type(str): An error type string from the IonQ REST API.
     """
 
+    def __init__(self, message, status_code, headers, body, error_type):  # pylint: disable=too-many-positional-arguments
+        super().__init__(message)
+        self.status_code = status_code
+        self.headers = headers
+        self.body = body
+        self.error_type = error_type
+
     @classmethod
     def raise_for_status(cls, response) -> IonQAPIError | None:
         """Raise an instance of the exception class from an API response object if needed.
@@ -151,13 +158,6 @@ class IonQAPIError(IonQError):
             error_type = error_data.get("type") or error_type
         return cls(message, status_code, headers, body, error_type)
 
-    def __init__(self, message, status_code, headers, body, error_type):  # pylint: disable=too-many-positional-arguments
-        super().__init__(message)
-        self.status_code = status_code
-        self.headers = headers
-        self.body = body
-        self.error_type = error_type
-
     def __str__(self):
         return (
             f"{self.__class__.__name__}("
@@ -168,17 +168,11 @@ class IonQAPIError(IonQError):
             f"error_type={self.error_type!r})"
         )
 
-    def __getstate__(self) -> object:
+    def __reduce__(self):
         return (
-            self.message,
-            self.status_code,
-            self.headers,
-            self.body,
-            self.error_type,
+            self.__class__,
+            (self.message, self.status_code, self.headers, self.body, self.error_type),
         )
-
-    def __setstate__(self, state: tuple[object, ...]) -> None:
-        self.message, self.status_code, self.headers, self.body, self.error_type = state
 
 
 class IonQBackendError(IonQError):

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -26,10 +26,11 @@
 
 """Test basic exceptions behavior"""
 
-from unittest import mock
-import requests
 import pickle
+from unittest import mock
+
 import pytest
+import requests
 
 from qiskit_ionq import exceptions
 from qiskit_ionq.exceptions import IonQRetriableError

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -296,4 +296,8 @@ def test_serializing_error():
         message="hi", status_code=400, headers="hi", body="hi", error_type="hi"
     )
     err2 = pickle.loads(pickle.dumps(err))
-    assert err == err2
+    assert err.message == err2.message
+    assert err.status_code == err2.status_code
+    assert err.headers == err2.headers
+    assert err.body == err2.body
+    assert err.error_type == err2.error_type

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -28,7 +28,7 @@
 
 from unittest import mock
 import requests
-
+import pickle
 import pytest
 
 from qiskit_ionq import exceptions
@@ -287,3 +287,13 @@ def test_error_format__default():
     assert err.headers == {"Content-Type": "text/html"}
     assert err.body == "<!doctype html><html><body>Hello IonQ!</body></html>"
     assert err.error_type == "internal_error"
+
+
+def test_serializing_error():
+    """Test that an error can be serialized and deserialized."""
+
+    err = exceptions.IonQAPIError(
+        message="hi", status_code=400, headers="hi", body="hi", error_type="hi"
+    )
+    err2 = pickle.loads(pickle.dumps(err))
+    assert err == err2


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

The bug can be reproduced with:
```python
from qiskit_ionq.exceptions import IonQAPIError
import pickle
err = IonQAPIError(message='hi', status_code=400, headers='hi', body='hi', error_type='hi')
pickle.loads(pickle.dumps(err))
```
which gives:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[5], line 4
      2 import pickle
      3 err = IonQAPIError(message='hi', status_code=400, headers='hi', body='hi', error_type='hi')
----> 4 pickle.loads(pickle.dumps(err))

TypeError: IonQAPIError.__init__() missing 4 required positional arguments: 'status_code', 'headers', 'body', and 'error_type'
```
