### PR TITLE
Use trusted publishing for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ jobs:
   publish-to-pypi:
     name: publish-to-pypi
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -24,8 +26,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./dist/qiskit*
-      - name: publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/qiskit*
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This enables us to stop using pypi tokens which are a security risk.