### PR TITLE
restrict qiskit version & p -> rz map

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -113,7 +113,7 @@ ionq_api_aliases = {  # todo fix alias bug
     "mcx": "cx",  # just one C for all mcx
     "mcx_gray": "cx",  # just one C for all mcx
     "tdg": "ti",
-    "p": "z",
+    "p": "rz",
     "PauliEvolution": "pauliexp",
     "rxx": "xx",
     "ryy": "yy",

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, patch
-VERSION_INFO = ".".join(map(str, (0, 5, 12)))
+VERSION_INFO = ".".join(map(str, (0, 5, 13)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ decorator>=5.1.0
 requests>=2.24.0
 importlib-metadata>=4.11.4
 python-dotenv>=1.0.1
-qiskit
+qiskit<=1.0.2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

maps p to rz instead of z

restricts qiskit version to 1.0.2 or earlier

### Details and comments

[this pr](https://github.com/Qiskit/qiskit/pull/11959) in 1.1.0 and after causes issues in transpilation