### PR TITLE
restrict qiskit version to 1.x

### DIFF
--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, patch
-VERSION_INFO = ".".join(map(str, (0, 5, 12)))
+VERSION_INFO = ".".join(map(str, (0, 5, 13)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-qiskit>=1.0.0
+qiskit<2.0.0
 Sphinx>=4.5.0
 sphinx-tabs>=1.1.11
 sphinx-autodoc-typehints

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-qiskit>=1.0.0
+qiskit<2.0.0
 pytest
 requests-mock>=1.8.0
 pytest-cov==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ decorator>=5.1.0
 requests>=2.24.0
 importlib-metadata>=4.11.4
 python-dotenv>=1.0.1
-qiskit
+qiskit<2.0.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

qiskit 2.0 breaks until we refactor from V1 classes

### Details and comments

restrict to qiskit 1.0 until work on V2 is done