### PR TITLE
Update intersphinx mapping and other URLs pointing to IQP Classic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,6 @@ autoclass_content = "both"
 #
 # Sphinx doc mappings
 intersphinx_mapping = {
-    "qiskit-terra": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit-terra": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
     "requests": ("https://requests.readthedocs.io/en/master/", None),
 }

--- a/example/example.ipynb
+++ b/example/example.ipynb
@@ -169,7 +169,7 @@
     "That said, there are a few things to note when running on IonQ backends: \n",
     "1. IonQ backends do not allow arbitrary unitaries, mid-circuit resets or measurements, or multi-experiment jobs. In practice, this means using `reset`, `initialize`, `u` `u1`, `u2`, `u3`, `cu`, `cu1`, `cu2`, or `cu3` gates will throw an exception on submission, as will measuring mid-circuit, and submmitting jobs with multiple experiments.\n",
     "2. while `barrier` is allowed for organizational and visualization purposes, the IonQ compiler does not see it as a compiler directive.\n",
-    "3. For the unitaries (`u`, `u1`, etc) and some other custom gates that [include appropriate decompositions](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.Instruction#add_decomposition), you can use the `transpile` method to rewrite your circuit into basis gates that the IonQ backends will take. See the example below.\n",
+    "3. For the unitaries (`u`, `u1`, etc) and some other custom gates that [include appropriate decompositions](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.circuit.Instruction#add_decomposition), you can use the `transpile` method to rewrite your circuit into basis gates that the IonQ backends will take. See the example below.\n",
     "4. The IonQ simulator API natively produces ideal probabilities based on a statevector simulation, not counts. For ease of interoperability and portability, this package uses a simple random sampling to produce \"counts,\" and also exposes the true probabilities. The code samples below show this in more detail."
    ]
   },


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.