### PR TITLE
Add YGate and update parameters for gate instructions in IonQBackend

### DIFF
--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -243,6 +243,10 @@ class IonQPauliExponentialError(IonQError):
     """Errors generated from improper usage of Pauli exponentials."""
 
 
+class IonQTranspileLevelWarning(UserWarning):
+    """Transpiler optimization level may degrade IonQ QIS results."""
+
+
 __all__ = [
     "IonQError",
     "IonQCredentialsError",
@@ -253,4 +257,6 @@ __all__ = [
     "IonQGateError",
     "IonQMidCircuitMeasurementError",
     "IonQJobTimeoutError",
+    "IonQPauliExponentialError",
+    "IonQTranspileLevelWarning",
 ]

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -723,15 +723,15 @@ def normalize(weights):
 
 
 def warn_bad_transpile_level():
-    """Warn if user default transpile_optimization_level is 2 or 3."""
+    """Warn if user default transpile_optimization_level is not 0 or 1."""
     cfg = get_config() or {}
-    lvl = cfg.get("transpile_optimization_level")
-    if lvl not in (0, 1):
+    opt_lvl = cfg.get("transpile_optimization_level", 2)
+    if opt_lvl not in (0, 1):
         warnings.warn(
-            "IonQ note: Your Qiskit 'transpile_optimization_level' is set to "
-            f"{lvl}. For IonQ backends we recommend 0 or 1 to avoid aggressive "
-            "re-synthesis that can inflate depth and degrade fidelity.",
-            UserWarning,
+            f"Transpiler default optimization_level={opt_lvl}. "
+            "IonQ (QIS) recommends 0-1 to avoid aggressive re-synthesis; "
+            "use transpile(..., optimization_level=1).",
+            ionq_exceptions.IonQTranspileLevelWarning,
             stacklevel=2,
         )
 

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -45,7 +45,8 @@ import requests
 from dotenv import dotenv_values
 
 import numpy as np
-from qiskit import __version__ as qiskit_terra_version
+from qiskit import __version__ as qiskit_version
+from qiskit.user_config import get_config
 from qiskit.circuit import (
     controlledgate as q_cgates,
     QuantumCircuit,
@@ -567,15 +568,13 @@ def get_user_agent() -> str:
     Returns:
         str: A string of generated user agent.
     """
-    # from qiskit_ionq import __version__ as qiskit_ionq_version
-
     os_string = f"os/{platform.system()}"
     provider_version_string = f"qiskit-ionq/{version('qiskit_ionq')}"
-    qiskit_terra_version_string = f"qiskit-terra/{qiskit_terra_version}"
+    qiskit_version_string = f"qiskit/{qiskit_version}"
     python_version_string = f"python/{platform.python_version()}"
     return (
         f"{provider_version_string} "
-        f"({qiskit_terra_version_string}) {os_string} "
+        f"({qiskit_version_string}) {os_string} "
         f"({python_version_string})"
     )
 
@@ -721,6 +720,20 @@ def normalize(weights):
     if total == 0:
         raise ValueError("sum of weights is zero")
     return arr / total
+
+
+def warn_bad_transpile_level():
+    """Warn if user default transpile_optimization_level is 2 or 3."""
+    cfg = get_config() or {}
+    lvl = cfg.get("transpile_optimization_level")
+    if lvl not in (0, 1):
+        warnings.warn(
+            "IonQ note: Your Qiskit 'transpile_optimization_level' is set to "
+            f"{lvl}. For IonQ backends we recommend 0 or 1 to avoid aggressive "
+            "re-synthesis that can inflate depth and degrade fidelity.",
+            UserWarning,
+            stacklevel=2,
+        )
 
 
 __all__ = [

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -62,6 +62,7 @@ from qiskit.circuit.library import (
     SXdgGate,
     TGate,
     TdgGate,
+    YGate,
     ZGate,
     PauliEvolutionGate,
 )
@@ -269,11 +270,12 @@ class IonQBackend(Backend):
         tgt = Target(num_qubits=self._num_qubits)
 
         if self._gateset == "qis":
-            theta, lam = Parameter("θ"), Parameter("λ")
+            theta = Parameter("θ")
             for gate in (
                 # 1-qubit (fixed)
                 IGate(),
                 XGate(),
+                YGate(),
                 ZGate(),
                 HGate(),
                 SGate(),
@@ -286,7 +288,7 @@ class IonQBackend(Backend):
                 RXGate(theta),
                 RYGate(theta),
                 RZGate(theta),
-                PhaseGate(lam),
+                PhaseGate(theta),
                 # 2-qubit (fixed)
                 CXGate(),
                 CYGate(),
@@ -298,20 +300,15 @@ class IonQBackend(Backend):
                 CRXGate(theta),
                 CRYGate(theta),
                 CRZGate(theta),
-                CPhaseGate(lam),
+                CPhaseGate(theta),
                 RXXGate(theta),
                 RYYGate(theta),
                 RZZGate(theta),
             ):
                 tgt.add_instruction(gate)
 
-            # MCX with 3 controls (4 total qubits)
-            tgt.add_instruction(MCXGate(3), name="mcx")
-
-            # Multi-controlled Phase (3 total qubits)
-            tgt.add_instruction(MCPhaseGate(lam, 2), name="mcphase")
-
-            # PauliEvolutionGate
+            tgt.add_instruction(MCXGate, name="mcx")
+            tgt.add_instruction(MCPhaseGate, name="mcphase")
             tgt.add_instruction(PauliEvolutionGate, name="PauliEvolution")
 
         else:

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -71,7 +71,7 @@ from qiskit.transpiler import Target, CouplingMap
 
 from qiskit_ionq.ionq_gates import GPIGate, GPI2Gate, MSGate, ZZGate
 from . import ionq_equivalence_library, ionq_job, ionq_client, exceptions
-from .helpers import GATESET_MAP, get_n_qubits
+from .helpers import GATESET_MAP, get_n_qubits, warn_bad_transpile_level
 from .ionq_client import Characterization
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -122,6 +122,9 @@ class IonQBackend(Backend):
         # Apply initial options if any
         if initial_options:
             self.options.update_options(**initial_options)
+
+        # Warn if optimization_level is set to a bad value (for IonQ)
+        warn_bad_transpile_level()
 
     @classmethod
     def _default_options(cls) -> Options:

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, patch
-VERSION_INFO = ".".join(map(str, (1, 0, 1)))
+VERSION_INFO = ".".join(map(str, (1, 0, 2)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/test/helpers/test_helpers.py
+++ b/test/helpers/test_helpers.py
@@ -40,13 +40,13 @@ def test_user_agent_header():
     ionq_client = IonQClient()
     generated_user_agent = ionq_client.api_headers["User-Agent"]
 
-    user_agent_info_keywords = ["qiskit-ionq", "qiskit-terra", "os", "python"]
+    user_agent_info_keywords = ["qiskit-ionq", "qiskit", "os", "python"]
     # Checks if all keywords are present in user-agent string.
     all_user_agent_keywords_avail = all(
         keyword in generated_user_agent for keyword in user_agent_info_keywords
     )
 
-    # Checks whether there is at-least 3 version strings from qiskit-ionq, qiskit-terra, python.
+    # Checks whether there is at-least 3 version strings from qiskit-ionq, qiskit, python.
     has_all_version_strings = len(re.findall(r"\s*([\d.]+)", generated_user_agent)) >= 3
     assert all_user_agent_keywords_avail and has_all_version_strings
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

- adds ygate
- fixes `MCX` and `MCPhase` gates

### Details and comments

```python
from qiskit import QuantumCircuit, transpile
from qiskit.circuit.library import PauliEvolutionGate
from qiskit.quantum_info import SparsePauliOp
from qiskit_ionq import IonQProvider

simulator_backend = IonQProvider().get_backend("simulator", gateset="qis")

operator = SparsePauliOp(["XX", "YY", "ZZ"], coeffs=[0.1, 0.2, 0.3])
evo = PauliEvolutionGate(operator, time=0.4)
circuit = QuantumCircuit(9)
circuit.append(evo, [0, 1])
circuit.mcx(list(range(7)), 8)
circuit.mcp(0.5, list(range(7)), 8)

t_circuit = transpile(
    circuit,
    backend=simulator_backend,
    optimization_level=1,
)
t_circuit.draw("mpl")
```

<img width="603" height="560" alt="image" src="https://github.com/user-attachments/assets/02acc706-6ec4-4b87-8dc3-b4aa2ebeb89b" />
