### PR TITLE
Add QASM3 export support for IonQ native gates

### DIFF
--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -29,6 +29,7 @@
 from typing import Optional
 import math
 import numpy as np
+from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
 
@@ -54,6 +55,13 @@ class GPIGate(Gate):
     def __init__(self, phi: ParameterValueType, label: Optional[str] = None):
         """Create new GPI gate."""
         super().__init__("gpi", 1, [phi], label=label)
+
+    def _define(self):
+        """Define the GPI gate in terms of standard gates for QASM export."""
+        qc = QuantumCircuit(1, name=self.name)
+        phi = self.params[0]
+        qc.u(math.pi, 2 * math.pi * phi, math.pi - 2 * math.pi * phi, 0)
+        self.definition = qc
 
     def __array__(self, dtype=None, copy=None):
         """Return a numpy array for the GPI gate."""
@@ -89,6 +97,18 @@ class GPI2Gate(Gate):
     def __init__(self, phi: ParameterValueType, label: Optional[str] = None):
         """Create new GPI2 gate."""
         super().__init__("gpi2", 1, [phi], label=label)
+
+    def _define(self):
+        """Define the GPI2 gate in terms of standard gates for QASM export."""
+        qc = QuantumCircuit(1, name=self.name)
+        phi = self.params[0]
+        qc.u(
+            math.pi / 2,
+            2 * math.pi * phi - math.pi / 2,
+            math.pi / 2 - 2 * math.pi * phi,
+            0,
+        )
+        self.definition = qc
 
     def __array__(self, dtype=None, copy=None):
         """Return a numpy array for the GPI2 gate."""
@@ -139,6 +159,17 @@ class MSGate(Gate):
             label=label,
         )
 
+    def _define(self):
+        """Define the MS gate in terms of standard gates for QASM export."""
+        qc = QuantumCircuit(2, name=self.name)
+        phi0, phi1, theta = self.params
+        qc.rz(-2 * math.pi * phi0, 0)
+        qc.rz(-2 * math.pi * phi1, 1)
+        qc.rxx(2 * math.pi * theta, 0, 1)
+        qc.rz(2 * math.pi * phi0, 0)
+        qc.rz(2 * math.pi * phi1, 1)
+        self.definition = qc
+
     def __array__(self, dtype=None, copy=None):
         """Return a numpy array for the MS gate."""
         phi0, phi1, theta = self.params
@@ -182,6 +213,13 @@ class ZZGate(Gate):
     def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
         """Create new ZZ gate."""
         super().__init__("zz", 2, [theta], label=label)
+
+    def _define(self):
+        """Define the ZZ gate in terms of standard gates for QASM export."""
+        qc = QuantumCircuit(2, name=self.name)
+        theta = self.params[0]
+        qc.rzz(2 * math.pi * theta, 0, 1)
+        self.definition = qc
 
     def __array__(self, dtype=None, copy=None) -> np.ndarray:
         """Return a numpy array for the ZZ gate."""

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 qiskit>=2.0.0
-openqasm3[parser]
+openqasm3[parser]>=1.0.0
 pytest
 requests-mock>=1.8.0
 pytest-cov>=2.10.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 qiskit>=2.0.0
+openqasm3[parser]
 pytest
 requests-mock>=1.8.0
 pytest-cov>=2.10.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
-qiskit>=2.0.0
-openqasm3[parser]>=1.0.0
+qiskit[qasm3-import]>=2.0.0
 pytest
 requests-mock>=1.8.0
 pytest-cov>=2.10.1

--- a/test/ionq_gates/test_gates.py
+++ b/test/ionq_gates/test_gates.py
@@ -33,7 +33,7 @@ import pytest
 
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import XGate, YGate, RXGate, RYGate, HGate
-from qiskit.qasm3 import dumps as qasm3_dumps
+from qiskit.qasm3 import dumps as qasm3_dumps, loads as qasm3_loads
 from qiskit.quantum_info import Operator
 from qiskit_ionq import GPIGate, GPI2Gate, MSGate, ZZGate
 
@@ -153,8 +153,6 @@ def test_zz_definition(angle):
 
 def test_qasm3_export():
     """Tests that circuits with IonQ native gates can be exported and parsed as QASM3."""
-    import openqasm3.parser
-
     circuit = QuantumCircuit(2)
     circuit.append(GPIGate(0.25), [0])
     circuit.append(GPI2Gate(0.5), [0])
@@ -170,13 +168,12 @@ def test_qasm3_export():
     assert "gate ms" in qasm3_str
     assert "gate zz" in qasm3_str
 
-    # Should not raise QASM3ParserError (issue #217).
-    openqasm3.parser.parse(qasm3_str)
+    # Should round-trip without raising (issue #217).
+    qasm3_loads(qasm3_str)
 
 
 def test_qasm_export_from_transpiled_circuit():
     """Tests QASM export and parse after transpiling to native gateset."""
-    import openqasm3.parser
     import qiskit
     import qiskit.qasm2
     import qiskit.qasm3
@@ -197,4 +194,4 @@ def test_qasm_export_from_transpiled_circuit():
     # QASM3 export and parse should work (issue #218).
     qasm3_str = qiskit.qasm3.dumps(transpiled)
     assert "gate gpi(" in qasm3_str or "gate gpi2(" in qasm3_str
-    openqasm3.parser.parse(qasm3_str)  # Should not raise QASM3ParserError
+    qasm3_loads(qasm3_str)  # Should round-trip without raising

--- a/test/ionq_gates/test_gates.py
+++ b/test/ionq_gates/test_gates.py
@@ -172,7 +172,7 @@ def test_qasm3_export():
     qasm3_loads(qasm3_str)
 
 
-def test_qasm_export_from_transpiled_circuit():
+def test_qasm_export_transpiled():
     """Tests QASM export and parse after transpiling to native gateset."""
     import qiskit
     import qiskit.qasm2

--- a/test/ionq_gates/test_gates.py
+++ b/test/ionq_gates/test_gates.py
@@ -31,7 +31,10 @@ import numpy as np
 
 import pytest
 
+from qiskit import QuantumCircuit
 from qiskit.circuit.library import XGate, YGate, RXGate, RYGate, HGate
+from qiskit.qasm3 import dumps as qasm3_dumps
+from qiskit.quantum_info import Operator
 from qiskit_ionq import GPIGate, GPI2Gate, MSGate, ZZGate
 
 
@@ -69,6 +72,15 @@ def test_gpi_inverse(phase):
     np.testing.assert_array_almost_equal(mat.dot(mat.conj().T), np.identity(2))
 
 
+@pytest.mark.parametrize("phase", [-0.5, -0.25, 0, 0.1, 0.25, 0.5, 0.75, 1.0])
+def test_gpi_definition(phase):
+    """Tests equivalence of the GPI gate matrix and its decomposition."""
+    gate = GPIGate(phase)
+    direct_mat = np.array(gate)
+    decomp_mat = Operator(gate.definition).data
+    np.testing.assert_array_almost_equal(direct_mat, decomp_mat)
+
+
 @pytest.mark.parametrize("phase", [0, 0.1, 0.4, np.pi / 2, np.pi, 2 * np.pi])
 def test_gpi2_inverse(phase):
     """Tests that the GPI2 gate is unitary."""
@@ -76,6 +88,15 @@ def test_gpi2_inverse(phase):
 
     mat = np.array(gate)
     np.testing.assert_array_almost_equal(mat.dot(mat.conj().T), np.identity(2))
+
+
+@pytest.mark.parametrize("phase", [-0.5, -0.25, 0, 0.1, 0.25, 0.5, 0.75, 1.0])
+def test_gpi2_definition(phase):
+    """Tests equivalence of the GPI2 gate matrix and its decomposition."""
+    gate = GPI2Gate(phase)
+    direct_mat = np.array(gate)
+    decomp_mat = Operator(gate.definition).data
+    np.testing.assert_array_almost_equal(direct_mat, decomp_mat)
 
 
 @pytest.mark.parametrize(
@@ -98,6 +119,18 @@ def test_ms_inverse(params):
 
 
 @pytest.mark.parametrize(
+    "params",
+    [(0, 0, 0.25), (0.1, 0.2, 0.25), (0.5, 0.5, 0.125)],
+)
+def test_ms_definition(params):
+    """Tests equivalence of the MS gate matrix and its decomposition."""
+    gate = MSGate(params[0], params[1], params[2])
+    direct_mat = np.array(gate)
+    decomp_mat = Operator(gate.definition).data
+    np.testing.assert_array_almost_equal(direct_mat, decomp_mat)
+
+
+@pytest.mark.parametrize(
     "angle",
     [0, 0.1, 0.4, np.pi / 2, np.pi, 2 * np.pi],
 )
@@ -107,3 +140,61 @@ def test_zz_inverse(angle):
 
     mat = np.array(gate)
     np.testing.assert_array_almost_equal(mat.dot(mat.conj().T), np.identity(4))
+
+
+@pytest.mark.parametrize("angle", [-0.5, -0.25, 0, 0.1, 0.25, 0.5, 0.75, 1.0])
+def test_zz_definition(angle):
+    """Tests equivalence of the ZZ gate matrix and its decomposition."""
+    gate = ZZGate(angle)
+    direct_mat = np.array(gate)
+    decomp_mat = Operator(gate.definition).data
+    np.testing.assert_array_almost_equal(direct_mat, decomp_mat)
+
+
+def test_qasm3_export():
+    """Tests that circuits with IonQ native gates can be exported and parsed as QASM3."""
+    import openqasm3.parser
+
+    circuit = QuantumCircuit(2)
+    circuit.append(GPIGate(0.25), [0])
+    circuit.append(GPI2Gate(0.5), [0])
+    circuit.append(MSGate(0.1, 0.2), [0, 1])
+    circuit.append(ZZGate(0.3), [0, 1])
+
+    # Should not raise QASM3ExporterError
+    qasm3_str = qasm3_dumps(circuit)
+
+    # Verify the output contains our gate definitions
+    assert "gate gpi" in qasm3_str
+    assert "gate gpi2" in qasm3_str
+    assert "gate ms" in qasm3_str
+    assert "gate zz" in qasm3_str
+
+    # Should not raise QASM3ParserError (issue #217).
+    openqasm3.parser.parse(qasm3_str)
+
+
+def test_qasm_export_from_transpiled_circuit():
+    """Tests QASM export and parse after transpiling to native gateset."""
+    import openqasm3.parser
+    import qiskit
+    import qiskit.qasm2
+    import qiskit.qasm3
+    from qiskit_ionq import IonQProvider
+
+    # Repro case from issue #217.
+    circuit = qiskit.QuantumCircuit(1)
+    circuit.u(0.1, 0.2, 0.3, 0)
+
+    provider = IonQProvider()
+    backend = provider.get_backend("simulator", gateset="native")
+
+    transpiled = qiskit.transpile(circuit, backend=backend, optimization_level=1)
+
+    # QASM2 export should work.
+    qasm2_str = qiskit.qasm2.dumps(transpiled)
+    assert "gate gpi" in qasm2_str or "gate gpi2" in qasm2_str
+    # QASM3 export and parse should work (issue #218).
+    qasm3_str = qiskit.qasm3.dumps(transpiled)
+    assert "gate gpi" in qasm3_str or "gate gpi2" in qasm3_str
+    openqasm3.parser.parse(qasm3_str)  # Should not raise QASM3ParserError

--- a/test/ionq_gates/test_gates.py
+++ b/test/ionq_gates/test_gates.py
@@ -193,8 +193,8 @@ def test_qasm_export_from_transpiled_circuit():
 
     # QASM2 export should work.
     qasm2_str = qiskit.qasm2.dumps(transpiled)
-    assert "gate gpi" in qasm2_str or "gate gpi2" in qasm2_str
+    assert "gate gpi(" in qasm2_str or "gate gpi2(" in qasm2_str
     # QASM3 export and parse should work (issue #218).
     qasm3_str = qiskit.qasm3.dumps(transpiled)
-    assert "gate gpi" in qasm3_str or "gate gpi2" in qasm3_str
+    assert "gate gpi(" in qasm3_str or "gate gpi2(" in qasm3_str
     openqasm3.parser.parse(qasm3_str)  # Should not raise QASM3ParserError


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

Adds QASM3 definitions for IonQ native gates so that output of `qiskit.qasm3.dumps` can be parsed by `openqasm3.parser` without error. Fixes #217 and #218.

### Details and comments

Adds `_define()` methods to all four IonQ native gates (`GPIGate`, `GPI2Gate`, `MSGate`, `ZZGate`). This provides decompositions into standard Qiskit gates that QASM exporters can serialize.

  **Gate decompositions:**
  | Gate | Decomposition |
  |------|---------------|
  | `GPIGate(φ)` | `U(π, 2πφ, π - 2πφ)` |
  | `GPI2Gate(φ)` | `U(π/2, 2πφ - π/2, π/2 - 2πφ)` |
  | `MSGate(φ0, φ1, θ)` | `RZ` + `RXX` + `RZ` sequence |
  | `ZZGate(θ)` | `RZZ(2πθ)` |

  **Testing:**
  - Added parametric tests verifying matrix equivalence between each gate and its decomposition.
  - Added integration tests for QASM3 export and parsing with `openqasm3.parser`.
  - Added test reproducing the exact scenario from issue #217.
