### PR TITLE
make simulator native target respect noise_model for gate selection

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -137,6 +137,24 @@ GATESET_MAP = {
     "native": ionq_native_basis_gates,
 }
 
+# Native 2-qubit entangling gate by IonQ device family. Add a row when a
+# new family ships; consulted by IonQBackend._make_target().
+NATIVE_2Q_BY_FAMILY: dict[str, Literal["ms", "zz"]] = {
+    "aria": "ms",
+    "forte": "zz",
+}
+
+
+def native_2q_gate(value: str | None) -> Literal["ms", "zz"] | None:
+    """Pick "ms"/"zz" implied by a backend name or noise_model, else None."""
+    if not isinstance(value, str):
+        return None
+    value = value.lower()
+    for fam, gate in NATIVE_2Q_BY_FAMILY.items():
+        if value == fam or f"{fam}-" in value or value.endswith((f".{fam}", f"_{fam}")):
+            return gate
+    return None
+
 
 def qiskit_circ_to_ionq_circ(
     input_circuit: QuantumCircuit,

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -118,6 +118,8 @@ class IonQBackend(Backend):
 
         # Target (basis & connectivity)
         self._target = self._make_target()
+        # Track noise_model for native simulator target caching
+        self._cached_noise_model: str | None = None
 
         # Apply initial options if any
         if initial_options:
@@ -141,6 +143,11 @@ class IonQBackend(Backend):
 
     @property
     def target(self) -> Target | None:
+        if self._simulator and self._gateset == "native":
+            current_noise_model = getattr(self.options, "noise_model", "ideal")
+            if self._cached_noise_model != current_noise_model:
+                self._target = self._make_target()
+                self._cached_noise_model = current_noise_model
         return self._target
 
     @property
@@ -321,7 +328,14 @@ class IonQBackend(Backend):
                 tgt.add_instruction(gate)
 
             # 2q native
-            if "forte" in self.name.lower():
+            noise_model = getattr(self.options, "noise_model", "ideal")
+            name_lower = self.name.lower()
+            name_is_forte = "forte-" in name_lower or name_lower.endswith("forte")
+            noise_model_is_forte = isinstance(noise_model, str) and (
+                noise_model.lower().startswith("forte")
+            )
+            use_zz = name_is_forte or noise_model_is_forte
+            if use_zz:
                 theta = Parameter("θ")
                 tgt.add_instruction(ZZGate(theta))
             else:

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -118,12 +118,8 @@ class IonQBackend(Backend):
 
         # Target (basis & connectivity)
         self._target = self._make_target()
-        # Track noise_model for native simulator target caching. Seeded with
-        # the same default _make_target() just used so the cache reflects
-        # actual state and we don't rebuild on the first .target access.
-        self._cached_noise_model: str | None = getattr(
-            self.options, "noise_model", "ideal"
-        )
+        # Track noise_model for native simulator target caching
+        self._cached_noise_model: str | None = None
 
         # Apply initial options if any
         if initial_options:
@@ -147,9 +143,6 @@ class IonQBackend(Backend):
 
     @property
     def target(self) -> Target | None:
-        # noise_model is a runtime option (settable via set_options after
-        # construction), so for native simulators the 2q basis gate (MS vs ZZ)
-        # can change post-__init__. Rebuild the Target lazily when it does.
         if self._simulator and self._gateset == "native":
             current_noise_model = getattr(self.options, "noise_model", "ideal")
             if self._cached_noise_model != current_noise_model:
@@ -334,11 +327,15 @@ class IonQBackend(Backend):
             for gate in (GPIGate(phi), GPI2Gate(phi)):
                 tgt.add_instruction(gate)
 
-            # 2q native: ZZ for Forte family, MS otherwise. Forte can be
-            # signaled either by the backend name (QPU) or by the noise_model
-            # option (simulator).
+            # 2q native
             noise_model = getattr(self.options, "noise_model", "ideal")
-            if self._is_forte(self.name) or self._is_forte(noise_model):
+            name_lower = self.name.lower()
+            name_is_forte = "forte-" in name_lower or name_lower.endswith("forte")
+            noise_model_is_forte = isinstance(noise_model, str) and (
+                noise_model.lower().startswith("forte")
+            )
+            use_zz = name_is_forte or noise_model_is_forte
+            if use_zz:
                 theta = Parameter("θ")
                 tgt.add_instruction(ZZGate(theta))
             else:
@@ -354,24 +351,6 @@ class IonQBackend(Backend):
     @staticmethod
     def _has_measurements(circ: QuantumCircuit) -> bool:
         return any(inst.operation.name == "measure" for inst in circ.data)
-
-    @staticmethod
-    def _is_forte(value: str | None) -> bool:
-        """Whether ``value`` names a Forte backend or noise model.
-
-        Matches ``forte-1``, ``forte-enterprise-1``, ``qpu.forte-1``, and the
-        bare token ``forte``; does not match unrelated substrings.
-
-        Args:
-            value (str | None): A backend name or noise_model string.
-
-        Returns:
-            bool: True if ``value`` denotes the Forte family.
-        """
-        if not isinstance(value, str):
-            return False
-        value = value.lower()
-        return value.startswith("forte") or "forte-" in value or value.endswith("forte")
 
 
 class IonQSimulatorBackend(IonQBackend):

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -71,7 +71,7 @@ from qiskit.transpiler import Target, CouplingMap
 
 from qiskit_ionq.ionq_gates import GPIGate, GPI2Gate, MSGate, ZZGate
 from . import ionq_equivalence_library, ionq_job, ionq_client, exceptions
-from .helpers import GATESET_MAP, get_n_qubits, warn_bad_transpile_level
+from .helpers import GATESET_MAP, get_n_qubits, native_2q_gate, warn_bad_transpile_level
 from .ionq_client import Characterization
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -327,15 +327,13 @@ class IonQBackend(Backend):
             for gate in (GPIGate(phi), GPI2Gate(phi)):
                 tgt.add_instruction(gate)
 
-            # 2q native
-            noise_model = getattr(self.options, "noise_model", "ideal")
-            name_lower = self.name.lower()
-            name_is_forte = "forte-" in name_lower or name_lower.endswith("forte")
-            noise_model_is_forte = isinstance(noise_model, str) and (
-                noise_model.lower().startswith("forte")
+            # 2q native: per family (see helpers.NATIVE_2Q_BY_FAMILY).
+            gate = (
+                native_2q_gate(self.name)
+                or native_2q_gate(getattr(self.options, "noise_model", None))
+                or "ms"
             )
-            use_zz = name_is_forte or noise_model_is_forte
-            if use_zz:
+            if gate == "zz":
                 theta = Parameter("θ")
                 tgt.add_instruction(ZZGate(theta))
             else:

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -118,8 +118,12 @@ class IonQBackend(Backend):
 
         # Target (basis & connectivity)
         self._target = self._make_target()
-        # Track noise_model for native simulator target caching
-        self._cached_noise_model: str | None = None
+        # Track noise_model for native simulator target caching. Seeded with
+        # the same default _make_target() just used so the cache reflects
+        # actual state and we don't rebuild on the first .target access.
+        self._cached_noise_model: str | None = getattr(
+            self.options, "noise_model", "ideal"
+        )
 
         # Apply initial options if any
         if initial_options:
@@ -143,6 +147,9 @@ class IonQBackend(Backend):
 
     @property
     def target(self) -> Target | None:
+        # noise_model is a runtime option (settable via set_options after
+        # construction), so for native simulators the 2q basis gate (MS vs ZZ)
+        # can change post-__init__. Rebuild the Target lazily when it does.
         if self._simulator and self._gateset == "native":
             current_noise_model = getattr(self.options, "noise_model", "ideal")
             if self._cached_noise_model != current_noise_model:
@@ -327,15 +334,11 @@ class IonQBackend(Backend):
             for gate in (GPIGate(phi), GPI2Gate(phi)):
                 tgt.add_instruction(gate)
 
-            # 2q native
+            # 2q native: ZZ for Forte family, MS otherwise. Forte can be
+            # signaled either by the backend name (QPU) or by the noise_model
+            # option (simulator).
             noise_model = getattr(self.options, "noise_model", "ideal")
-            name_lower = self.name.lower()
-            name_is_forte = "forte-" in name_lower or name_lower.endswith("forte")
-            noise_model_is_forte = isinstance(noise_model, str) and (
-                noise_model.lower().startswith("forte")
-            )
-            use_zz = name_is_forte or noise_model_is_forte
-            if use_zz:
+            if self._is_forte(self.name) or self._is_forte(noise_model):
                 theta = Parameter("θ")
                 tgt.add_instruction(ZZGate(theta))
             else:
@@ -351,6 +354,24 @@ class IonQBackend(Backend):
     @staticmethod
     def _has_measurements(circ: QuantumCircuit) -> bool:
         return any(inst.operation.name == "measure" for inst in circ.data)
+
+    @staticmethod
+    def _is_forte(value: str | None) -> bool:
+        """Whether ``value`` names a Forte backend or noise model.
+
+        Matches ``forte-1``, ``forte-enterprise-1``, ``qpu.forte-1``, and the
+        bare token ``forte``; does not match unrelated substrings.
+
+        Args:
+            value (str | None): A backend name or noise_model string.
+
+        Returns:
+            bool: True if ``value`` denotes the Forte family.
+        """
+        if not isinstance(value, str):
+            return False
+        value = value.lower()
+        return value.startswith("forte") or "forte-" in value or value.endswith("forte")
 
 
 class IonQSimulatorBackend(IonQBackend):

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -30,7 +30,7 @@
 from unittest import mock
 
 import pytest
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, transpile
 
 from qiskit_ionq import exceptions, ionq_client, ionq_job
 from qiskit_ionq.helpers import get_user_agent
@@ -314,3 +314,47 @@ def test_backend_memory(
     job = ionq_job.IonQJob(mock_backend, job_id)
     with pytest.raises(AttributeError):
         job.get_memory()  # pylint: disable=no-member
+
+
+def test_simulator_native_target_respects_noise_model(provider):
+    """Test that simulator native target uses ZZ gate for Forte noise models.
+
+    Args:
+        provider: A test IonQProvider.
+    """
+    sim_backend = provider.get_backend("ionq_simulator", gateset="native")
+
+    target_ops = [op.name for op in sim_backend.target.operations]
+    assert "ms" in target_ops
+    assert "zz" not in target_ops
+
+    sim_backend.set_options(noise_model="forte-1")
+    target_ops = [op.name for op in sim_backend.target.operations]
+    assert "zz" in target_ops
+    assert "ms" not in target_ops
+
+    sim_backend.set_options(noise_model="aria-1")
+    target_ops = [op.name for op in sim_backend.target.operations]
+    assert "ms" in target_ops
+    assert "zz" not in target_ops
+
+
+def test_forte_noise_model_transpiles_rzz_to_zz(provider):
+    """Test that rzz gates transpile to zz (not ms) with Forte noise model.
+
+    Regression test for issue #210.
+
+    Args:
+        provider: A test IonQProvider.
+    """
+    native_simulator = provider.get_backend("ionq_simulator", gateset="native")
+    native_simulator.set_options(noise_model="forte-1")
+
+    qc = QuantumCircuit(2)
+    qc.rzz(1, 0, 1)
+
+    transpiled_qc = transpile(qc, backend=native_simulator, optimization_level=3)
+    ops = transpiled_qc.count_ops()
+
+    assert "zz" in ops
+    assert "ms" not in ops

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -316,11 +316,11 @@ def test_backend_memory(
         job.get_memory()  # pylint: disable=no-member
 
 
-def test_simulator_native_target_respects_noise_model(provider):
+def test_native_sim_target_noise(provider):
     """Test that simulator native target uses ZZ gate for Forte noise models.
 
     Args:
-        provider: A test IonQProvider.
+        provider (IonQProvider): A test IonQProvider.
     """
     sim_backend = provider.get_backend("ionq_simulator", gateset="native")
 
@@ -339,13 +339,13 @@ def test_simulator_native_target_respects_noise_model(provider):
     assert "zz" not in target_ops
 
 
-def test_forte_noise_model_transpiles_rzz_to_zz(provider):
+def test_forte_rzz_transpiles_to_zz(provider):
     """Test that rzz gates transpile to zz (not ms) with Forte noise model.
 
     Regression test for issue #210.
 
     Args:
-        provider: A test IonQProvider.
+        provider (IonQProvider): A test IonQProvider.
     """
     native_simulator = provider.get_backend("ionq_simulator", gateset="native")
     native_simulator.set_options(noise_model="forte-1")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

When a simulator is used with `noise_model='forte-1'`, transpilation will use Forte's native entangling gates ZZ instead of the default/Aria's native MS gates. Fixes #210.

### Details and comments

Partial support was added in #231 but that change only checked the backend name to choose between ZZ and MS, which only works for QPU backends but not the simulators (the name `ionq_simulator` doesn't contain `forte`).

This PR checks `noise_model` in addition to the backend name. It also rebuilds the target dynamically for native simulators. This is necessary because `noise_model` is a runtime option (which can change after backend creation).
