### PR TITLE
fix: handle null metadata on retrieved job responses

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -390,18 +390,20 @@ def compress_to_metadata_string(
 
 
 def decompress_metadata_string(
-    input_string: str,
-) -> dict | list:  # pylint: disable=invalid-name
+    input_string: str | None,
+) -> dict | list | None:  # pylint: disable=invalid-name
     """
     Convert compact string format (dumped, gzipped, base64 encoded) from
     IonQ API metadata back into a dict or list of dicts relevant to building
     the results object on a returned job.
 
     Parameters:
-        input_string (str): compressed string format of metadata dict
+        input_string (str | None): compressed string format of metadata dict,
+            or None when the API omitted metadata.
 
     Returns:
-        dict or list: decompressed metadata dict or list of dicts
+        dict or list or None: decompressed metadata, or None if the input
+        was None.
     """
     if input_string is None:
         return None

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -392,12 +392,13 @@ class IonQJob(JobV1):
 
             # Classical-bit maps for every circuit
             header_list = decompress_metadata_string(
-                response.get("metadata", {}).get("qiskit_header")
+                (response.get("metadata") or {}).get("qiskit_header")
             )
             if not isinstance(header_list, list):
                 header_list = [header_list]
             self._clbits = [
-                _meas_map_from_header(h, self._num_qubits) for h in header_list
+                _meas_map_from_header(h or {}, self._num_qubits)
+                for h in header_list
             ]
 
             # Ensure one map per circuit
@@ -543,10 +544,22 @@ class IonQJob(JobV1):
         ]
         if self._status == jobstatus.JobStatus.DONE:
             for i in range(self._num_circuits):
+                n_qubits = (qiskit_header[i] or {}).get(
+                    "n_qubits", self._num_qubits
+                )
+                clbits = self._clbits[i]
+
+                # When metadata is absent (e.g. job submitted outside qiskit),
+                # infer the qubit count from the highest result key so that the
+                # measurement map is not empty.
+                if not clbits and data[i]:
+                    n_qubits = max(int(k) for k in data[i]).bit_length() or 1
+                    clbits = list(range(n_qubits))
+
                 (counts, probabilities) = _build_counts(
                     data[i],
-                    qiskit_header[i].get("n_qubits", self._num_qubits),
-                    self._clbits[i],
+                    n_qubits,
+                    clbits,
                     shots,
                     use_sampler=is_ideal_sim,
                     sampler_seed=sampler_seed,

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -391,14 +391,14 @@ class IonQJob(JobV1):
                 return mmap
 
             # Classical-bit maps for every circuit
-            header_list = decompress_metadata_string(
-                (response.get("metadata") or {}).get("qiskit_header")
+            metadata = response.get("metadata") or {}
+            header_list = (
+                decompress_metadata_string(metadata.get("qiskit_header")) or {}
             )
             if not isinstance(header_list, list):
                 header_list = [header_list]
             self._clbits = [
-                _meas_map_from_header(h or {}, self._num_qubits)
-                for h in header_list
+                _meas_map_from_header(h, self._num_qubits) for h in header_list
             ]
 
             # Ensure one map per circuit
@@ -508,7 +508,7 @@ class IonQJob(JobV1):
             if metadata.get("sampler_seed", "").isdigit()
             else None
         )
-        qiskit_header = decompress_metadata_string(metadata.get("qiskit_header"))
+        qiskit_header = decompress_metadata_string(metadata.get("qiskit_header")) or {}
         if not isinstance(qiskit_header, list):
             qiskit_header = [qiskit_header]
 
@@ -544,21 +544,16 @@ class IonQJob(JobV1):
         ]
         if self._status == jobstatus.JobStatus.DONE:
             for i in range(self._num_circuits):
-                n_qubits = (qiskit_header[i] or {}).get(
-                    "n_qubits", self._num_qubits
-                )
+                # Infer clbits from result keys when metadata is absent
+                # (e.g. job submitted outside qiskit); map_output returns
+                # nothing for an empty clbits list.
                 clbits = self._clbits[i]
-
-                # When metadata is absent (e.g. job submitted outside qiskit),
-                # infer the qubit count from the highest result key so that the
-                # measurement map is not empty.
                 if not clbits and data[i]:
                     n_qubits = max(int(k) for k in data[i]).bit_length() or 1
                     clbits = list(range(n_qubits))
-
                 (counts, probabilities) = _build_counts(
                     data[i],
-                    n_qubits,
+                    qiskit_header[i].get("n_qubits", len(clbits) or self._num_qubits),
                     clbits,
                     shots,
                     use_sampler=is_ideal_sim,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -176,6 +176,41 @@ def dummy_mapped_job_response(
     return response
 
 
+def dummy_multicircuit_parent_response(job_id, child_job_ids, status="completed"):
+    """A dummy parent response for a multicircuit job, matching the real IonQ API shape.
+
+    The IonQ API returns ``metadata: null`` and empty ``stats`` on the parent
+    job for multicircuit submissions that did not include qiskit metadata.
+
+    Args:
+        job_id (str): The parent job id.
+        child_job_ids (list[str]): Child job ids.
+        status (str): Job status string.
+
+    Returns:
+        dict: A json response dict.
+    """
+    return {
+        "id": job_id,
+        "type": "ionq.multi-circuit.v1",
+        "status": status,
+        "name": f"{len(child_job_ids)} circuits",
+        "metadata": None,
+        "backend": "simulator",
+        "child_job_ids": child_job_ids,
+        "settings": {},
+        "stats": {},
+        "results": {
+            "probabilities": {
+                "url": (
+                    f"/v0.4/jobs/{job_id}/results/probabilities/aggregated"
+                )
+            }
+        },
+        "execution_duration_ms": 0,
+    }
+
+
 def dummy_failed_job(job_id):  # pylint: disable=differing-param-doc,differing-type-doc
     """A dummy response payload for a failed job.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -176,11 +176,9 @@ def dummy_mapped_job_response(
     return response
 
 
-def dummy_multicircuit_parent_response(job_id, child_job_ids, status="completed"):
-    """A dummy parent response for a multicircuit job, matching the real IonQ API shape.
-
-    The IonQ API returns ``metadata: null`` and empty ``stats`` on the parent
-    job for multicircuit submissions that did not include qiskit metadata.
+def dummy_multi_parent_response(job_id, child_job_ids, status="completed"):
+    """Multicircuit parent response with ``metadata: null`` and empty ``stats``,
+    matching the wire shape returned for jobs submitted outside qiskit.
 
     Args:
         job_id (str): The parent job id.
@@ -190,6 +188,7 @@ def dummy_multicircuit_parent_response(job_id, child_job_ids, status="completed"
     Returns:
         dict: A json response dict.
     """
+    url = f"/v0.4/jobs/{job_id}/results/probabilities/aggregated"
     return {
         "id": job_id,
         "type": "ionq.multi-circuit.v1",
@@ -200,13 +199,7 @@ def dummy_multicircuit_parent_response(job_id, child_job_ids, status="completed"
         "child_job_ids": child_job_ids,
         "settings": {},
         "stats": {},
-        "results": {
-            "probabilities": {
-                "url": (
-                    f"/v0.4/jobs/{job_id}/results/probabilities/aggregated"
-                )
-            }
-        },
+        "results": {"probabilities": {"url": url}},
         "execution_duration_ms": 0,
     }
 

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -874,3 +874,68 @@ def test_multi_circuit_clbit_map(mock_backend, requests_mock):
 
     job = ionq_job.IonQJob(mock_backend, job_id)
     assert job._clbits == meas_maps
+
+
+def test_multicircuit_null_metadata_status(mock_backend, requests_mock):
+    """Retrieving a multicircuit job whose parent has ``metadata: null``
+    (e.g. a job submitted outside qiskit) must not crash in status().
+    """
+    job_id = "parent_null_meta"
+    child_ids = ["child_a", "child_b"]
+    parent = conftest.dummy_multicircuit_parent_response(job_id, child_ids)
+
+    client = mock_backend.client
+    requests_mock.get(
+        client.make_path("jobs", job_id), status_code=200, json=parent
+    )
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+
+    assert job._status == jobstatus.JobStatus.DONE
+    assert job._num_circuits == 2
+    # With no qiskit_header the fallback meas-map is range(_num_qubits).
+    # _num_qubits is 0 (empty stats), so each clbits list is [].
+    assert job._clbits == [[], []]
+    assert job._results_url.endswith("/aggregated")
+
+
+def test_multicircuit_null_metadata_result(mock_backend, requests_mock):
+    """End-to-end result retrieval for a multicircuit parent with
+    ``metadata: null``.  The aggregated results endpoint returns a
+    dict-of-dicts keyed by child job id.
+    """
+    job_id = "parent_null_meta_result"
+    child_ids = ["child_r1", "child_r2"]
+    parent = conftest.dummy_multicircuit_parent_response(job_id, child_ids)
+
+    client = mock_backend.client
+    requests_mock.get(
+        client.make_path("jobs", job_id), status_code=200, json=parent
+    )
+
+    # Aggregated results keyed by child job id.
+    # Circuit 0: Bell state (keys 0 and 3 need 2 qubits).
+    # Circuit 1: X on qubit 0 (key 1 needs 1 qubit).
+    aggregated = {
+        child_ids[0]: {"0": 0.5, "3": 0.5},
+        child_ids[1]: {"1": 1.0},
+    }
+    results_path = client.make_path(
+        "jobs", job_id, "results", "probabilities", "aggregated"
+    )
+    requests_mock.get(results_path, status_code=200, json=aggregated)
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    result = job.result()
+
+    assert result.success is True
+    assert len(result.results) == 2
+
+    # Qubit count is inferred from the result keys.
+    # Circuit 0: max key 3 -> bit_length 2 -> 2-qubit bitstrings.
+    counts_0 = result.get_counts(0)
+    assert counts_0 == {"00": 512, "11": 512}
+
+    # Circuit 1: max key 1 -> bit_length 1 -> 1-qubit bitstrings.
+    counts_1 = result.get_counts(1)
+    assert counts_1 == {"1": 1024}

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -876,66 +876,26 @@ def test_multi_circuit_clbit_map(mock_backend, requests_mock):
     assert job._clbits == meas_maps
 
 
-def test_multicircuit_null_metadata_status(mock_backend, requests_mock):
-    """Retrieving a multicircuit job whose parent has ``metadata: null``
-    (e.g. a job submitted outside qiskit) must not crash in status().
+def test_multi_null_meta_result(mock_backend, requests_mock):
+    """Multicircuit parent with ``metadata: null`` (raw-submitted) must not
+    crash on retrieval; qubit count is inferred from result keys.
     """
     job_id = "parent_null_meta"
     child_ids = ["child_a", "child_b"]
-    parent = conftest.dummy_multicircuit_parent_response(job_id, child_ids)
+    parent = conftest.dummy_multi_parent_response(job_id, child_ids)
+    aggregated = {child_ids[0]: {"0": 0.5, "3": 0.5}, child_ids[1]: {"1": 1.0}}
 
     client = mock_backend.client
+    requests_mock.get(client.make_path("jobs", job_id), json=parent)
     requests_mock.get(
-        client.make_path("jobs", job_id), status_code=200, json=parent
+        client.make_path("jobs", job_id, "results", "probabilities", "aggregated"),
+        json=aggregated,
     )
 
-    job = ionq_job.IonQJob(mock_backend, job_id)
-
-    assert job._status == jobstatus.JobStatus.DONE
-    assert job._num_circuits == 2
-    # With no qiskit_header the fallback meas-map is range(_num_qubits).
-    # _num_qubits is 0 (empty stats), so each clbits list is [].
-    assert job._clbits == [[], []]
-    assert job._results_url.endswith("/aggregated")
-
-
-def test_multicircuit_null_metadata_result(mock_backend, requests_mock):
-    """End-to-end result retrieval for a multicircuit parent with
-    ``metadata: null``.  The aggregated results endpoint returns a
-    dict-of-dicts keyed by child job id.
-    """
-    job_id = "parent_null_meta_result"
-    child_ids = ["child_r1", "child_r2"]
-    parent = conftest.dummy_multicircuit_parent_response(job_id, child_ids)
-
-    client = mock_backend.client
-    requests_mock.get(
-        client.make_path("jobs", job_id), status_code=200, json=parent
-    )
-
-    # Aggregated results keyed by child job id.
-    # Circuit 0: Bell state (keys 0 and 3 need 2 qubits).
-    # Circuit 1: X on qubit 0 (key 1 needs 1 qubit).
-    aggregated = {
-        child_ids[0]: {"0": 0.5, "3": 0.5},
-        child_ids[1]: {"1": 1.0},
-    }
-    results_path = client.make_path(
-        "jobs", job_id, "results", "probabilities", "aggregated"
-    )
-    requests_mock.get(results_path, status_code=200, json=aggregated)
-
-    job = ionq_job.IonQJob(mock_backend, job_id)
-    result = job.result()
+    result = ionq_job.IonQJob(mock_backend, job_id).result()
 
     assert result.success is True
-    assert len(result.results) == 2
-
-    # Qubit count is inferred from the result keys.
-    # Circuit 0: max key 3 -> bit_length 2 -> 2-qubit bitstrings.
-    counts_0 = result.get_counts(0)
-    assert counts_0 == {"00": 512, "11": 512}
-
-    # Circuit 1: max key 1 -> bit_length 1 -> 1-qubit bitstrings.
-    counts_1 = result.get_counts(1)
-    assert counts_1 == {"1": 1024}
+    # Bell: max key 3 -> 2 qubits inferred -> 2-char bitstrings.
+    assert result.get_counts(0) == {"00": 512, "11": 512}
+    # X: max key 1 -> 1 qubit inferred -> 1-char bitstrings.
+    assert result.get_counts(1) == {"1": 1024}


### PR DESCRIPTION
## Bug

`IonQJob` retrieval crashes with `AttributeError: 'NoneType' object has no attribute 'get'` for **any** job whose response body has `metadata: null` — the wire shape the IonQ API returns for jobs submitted outside qiskit (raw REST, `ionq-core`, other SDKs). Affects both `ionq.circuit.v1` (single) and `ionq.multi-circuit.v1` (parent) responses.

`response.get("metadata", {}).get("qiskit_header")` does **not** guard against a present-but-null value: when `"metadata"` exists with value `None`, the default `{}` is not used and `None.get(...)` raises in `IonQJob.status()`.

## Fix

- Coalesce null metadata to `{}` at the two `decompress_metadata_string(...)` call sites in `ionq_job.py` (`status()` and `_format_result()`). Resolves the crash for both single- and multi-circuit retrieval.
- For multicircuit parents only: the API also returns `stats: {}` on the parent (per-child stats live on the children), so `_num_qubits = 0` and `_clbits[i] = []`. When that happens, infer the qubit count from the highest result key so `map_output` / `_build_counts` produce correct bitstrings.
- Update `decompress_metadata_string`'s signature to `str | None -> dict | list | None` to match what it already does at runtime.

## Test plan

- [x] New end-to-end test `test_multi_null_meta_result` exercises retrieval through `IonQJob` with the canonical null-metadata wire shape; asserts inferred qubit counts produce correct bitstrings (Bell circuit → 2-char keys, single-X circuit → 1-char keys).
- [x] All existing tests still pass (340 incl. the new test).
- [x] Verified end-to-end against `https://api.ionq.co/v0.4` simulator with freshly-submitted raw jobs in **both** shapes (single `ionq.circuit.v1` and `ionq.multi-circuit.v1` parents); on `main` both crash at `ionq_job.py:395`, on this branch both return correct counts and probabilities.
