### PR TITLE
Support dry_run / compilation-as-a-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ print(job.result(sharpen=True).get_counts())
 print(job.result().get_probabilities())
 ```
 
+### Compilation as a service (`dry_run`)
+
+IonQ Cloud can compile a circuit and return the result _without_ executing it on a QPU. This is useful for inspecting the post-compilation circuit, estimating gate counts, or validating native-gate output before paying for shots.
+
+Set `dry_run=True` on `backend.run(...)` and then read the compiled circuit back via `job.compiled_circuit(...)`:
+
+```python
+backend = provider.get_backend("ionq_qpu.forte-1")
+
+job = backend.run(qc, dry_run=True)
+job.wait_for_final_state()
+
+native_json = job.compiled_circuit(lang="native")   # IonQ-native JSON
+qasm3       = job.compiled_circuit(lang="qasm3")    # OpenQASM 3
+```
+
+Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
+
 ### Basis gates and transpilation
 
 The IonQ provider provides access to the full IonQ Cloud backend, which includes its own transpilation and compilation pipeline. As such, IonQ provider backends have a broad set of "basis gates" that they will accept — effectively anything the IonQ API will accept. The current supported gates can be found [on our docs site](https://docs.ionq.com/#tag/quantum_programs).

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -552,6 +552,11 @@ def qiskit_to_ionq(
     if settings:
         ionq_json["settings"] = settings
 
+    # dry-run flag (compilation-as-a-service); only emit when truthy so we
+    # don't clobber a user-supplied extra_query_params={"dry_run": True}.
+    if passed_args.get("dry_run"):
+        ionq_json["dry_run"] = True
+
     # user-supplied extras & final serialization
     ionq_json.update(extra_query_params)
     ionq_json["metadata"].update(extra_metadata)

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -137,6 +137,7 @@ class IonQBackend(Backend):
             extra_metadata={},
             sampler_seed=None,  # simulator-only (harmless on QPU)
             noise_model="ideal",  # simulator-only
+            dry_run=False,  # if True, the API compiles but does not execute
         )
 
     @property

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -258,21 +258,24 @@ class IonQClient:
 
         Args:
             job_id (str): The ID of the job whose compiled circuit to fetch.
-            lang (str): Output language; one of ``"native"`` or ``"qasm3"``.
-                Defaults to ``"native"``.
+            lang (str): Output language. ``"native"`` (default) returns the
+                IonQ-native gate JSON; ``"qasm3"`` returns OpenQASM 3 source.
+                Other values may be accepted depending on organization
+                entitlement; consult the IonQ API reference for the current
+                set. Unsupported or non-entitled values are rejected by the
+                API with a ``4xx`` response.
 
         Raises:
-            IonQAPIError: When the API returns a non-200 status code.
+            IonQAPIError: When the API returns a non-2xx status code (this
+                covers both unsupported ``lang`` values and per-organization
+                entitlement rejections).
             IonQRetriableError: When a retriable error occurs during the request.
-            ValueError: If ``lang`` is not one of the supported values.
 
         Returns:
             str: The compiled circuit as a string. For ``lang="qasm3"`` this is
             an OpenQASM 3 program; for ``lang="native"`` this is the IonQ JSON
             circuit representation in native gates.
         """
-        if lang not in ("native", "qasm3"):
-            raise ValueError(f"lang must be 'native' or 'qasm3', got {lang!r}.")
         req_path = self.make_path("jobs", job_id, "circuits", lang)
         res = self.get_with_retry(req_path, headers=self.api_headers)
         exceptions.IonQAPIError.raise_for_status(res)

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -272,9 +272,7 @@ class IonQClient:
             circuit representation in native gates.
         """
         if lang not in ("native", "qasm3"):
-            raise ValueError(
-                f"lang must be 'native' or 'qasm3', got {lang!r}."
-            )
+            raise ValueError(f"lang must be 'native' or 'qasm3', got {lang!r}.")
         req_path = self.make_path("jobs", job_id, "circuits", lang)
         res = self.get_with_retry(req_path, headers=self.api_headers)
         exceptions.IonQAPIError.raise_for_status(res)

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -248,6 +248,44 @@ class IonQClient:
         )
 
     @retry(exceptions=IonQRetriableError, max_delay=60, backoff=2, jitter=1)
+    def get_compiled_circuit(self, job_id: str, lang: str = "native") -> str:
+        """Retrieve the server-compiled circuit for a job.
+
+        Hits ``GET /v0.4/jobs/{UUID}/circuits/{lang}``, which is populated by the
+        IonQ Cloud compiler-as-a-service for jobs submitted with ``dry_run=True``
+        (and, for fully-executed jobs, the post-compilation circuit actually run
+        on hardware).
+
+        Args:
+            job_id (str): The ID of the job whose compiled circuit to fetch.
+            lang (str): Output language; one of ``"native"`` or ``"qasm3"``.
+                Defaults to ``"native"``.
+
+        Raises:
+            IonQAPIError: When the API returns a non-200 status code.
+            IonQRetriableError: When a retriable error occurs during the request.
+            ValueError: If ``lang`` is not one of the supported values.
+
+        Returns:
+            str: The compiled circuit as a string. For ``lang="qasm3"`` this is
+            an OpenQASM 3 program; for ``lang="native"`` this is the IonQ JSON
+            circuit representation in native gates.
+        """
+        if lang not in ("native", "qasm3"):
+            raise ValueError(
+                f"lang must be 'native' or 'qasm3', got {lang!r}."
+            )
+        req_path = self.make_path("jobs", job_id, "circuits", lang)
+        res = self.get_with_retry(req_path, headers=self.api_headers)
+        exceptions.IonQAPIError.raise_for_status(res)
+        # The API returns a JSON-encoded string body; .json() unwraps the outer
+        # quotes and returns a plain Python str.
+        try:
+            return res.json()
+        except ValueError:
+            return res.text
+
+    @retry(exceptions=IonQRetriableError, max_delay=60, backoff=2, jitter=1)
     def get_results(
         self,
         results_url: str,

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -225,13 +225,17 @@ class IonQJob(JobV1):
         actually run on hardware after IonQ's compiler resynthesizes the input.
 
         Args:
-            lang (str): One of ``"native"`` or ``"qasm3"``. Defaults to
-                ``"native"``.
+            lang (str): Output language. ``"native"`` (default) returns the
+                IonQ-native gate JSON; ``"qasm3"`` returns OpenQASM 3 source.
+                Other values may be accepted depending on organization
+                entitlement; the API rejects unsupported or non-entitled
+                values with a ``4xx`` response surfaced here as
+                :class:`~qiskit_ionq.exceptions.IonQAPIError`.
 
         Raises:
             IonQJobStateError: If the job has not reached a final state yet.
             IonQJobFailureError: If the job failed before compilation completed.
-            ValueError: If ``lang`` is not a supported value.
+            IonQAPIError: If the API rejects the ``lang`` value.
 
         Returns:
             str: The compiled circuit as a string (IonQ-native JSON or OpenQASM 3).

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -175,6 +175,8 @@ class IonQJob(JobV1):
         self._result = None
         self._status = None
         self._execution_time = None
+        self._dry_run: bool = False
+        self._results_url: str | None = None
         self._metadata: dict[str, Any] = {}
 
         if passed_args is not None:
@@ -203,6 +205,47 @@ class IonQJob(JobV1):
             if k in mapping and mapping[k] is not None:
                 return mapping[k]
         return default
+
+    @property
+    def dry_run(self) -> bool:
+        """Whether this job was submitted with ``dry_run=True``.
+
+        Dry-run jobs are compiled by the IonQ Cloud compiler-as-a-service but
+        not executed - they produce no measurement results. Use
+        :meth:`compiled_circuit` to retrieve the compiled circuit instead of
+        :meth:`result`.
+        """
+        return self._dry_run
+
+    def compiled_circuit(self, lang: str = "native") -> str:
+        """Fetch the server-compiled circuit for this job.
+
+        Useful for jobs submitted with ``dry_run=True`` (compilation as a
+        service) but also works for any completed job to inspect what was
+        actually run on hardware after IonQ's compiler resynthesizes the input.
+
+        Args:
+            lang (str): One of ``"native"`` or ``"qasm3"``. Defaults to
+                ``"native"``.
+
+        Raises:
+            IonQJobStateError: If the job has not reached a final state yet.
+            IonQJobFailureError: If the job failed before compilation completed.
+            ValueError: If ``lang`` is not a supported value.
+
+        Returns:
+            str: The compiled circuit as a string (IonQ-native JSON or OpenQASM 3).
+        """
+        # Make sure we're in a final state and the job-id is known. status()
+        # raises IonQJobFailureError on failure, which is the right behavior.
+        self.status()
+        if self._status not in jobstatus.JOB_FINAL_STATES:
+            raise exceptions.IonQJobStateError(
+                "Cannot fetch compiled circuit until the job reaches a final state. "
+                "Call wait_for_final_state() first."
+            )
+        assert self._job_id is not None
+        return self._client.get_compiled_circuit(self._job_id, lang=lang)
 
     def cancel(self) -> None:
         """Cancel this job."""
@@ -308,6 +351,13 @@ class IonQJob(JobV1):
 
         if self._status is jobstatus.JobStatus.DONE:
             assert self._job_id is not None
+            if self._dry_run:
+                raise exceptions.IonQJobError(
+                    f"Job {self._job_id} was submitted with dry_run=True; "
+                    "no measurement results are produced. Use "
+                    "job.compiled_circuit(lang='native' or 'qasm3') to "
+                    "retrieve the compiled circuit instead."
+                )
             response = self._client.get_results(
                 results_url=self._results_url,
                 sharpen=sharpen,
@@ -359,6 +409,10 @@ class IonQJob(JobV1):
             self._save_metadata(response)
 
         if self._status == jobstatus.JobStatus.DONE:
+            # Track dry-run regardless of source; the API echoes it as a
+            # top-level boolean on the job response.
+            self._dry_run = bool(response.get("dry_run", False))
+
             stats = response.get("stats", {})
             self._children = self._first_of(
                 response, "child_job_ids", "children", default=None
@@ -371,18 +425,27 @@ class IonQJob(JobV1):
                 self._num_circuits = self._first_of(stats, "circuits", default=1)
 
             self._num_qubits = self._first_of(stats, "qubits", default=0)
-            _results_url = self._first_of(
-                response, "results", "results_url", default={}
-            )
-            self._results_url = (
-                _results_url
-                if isinstance(_results_url, str)
-                else _results_url.get("probabilities", {}).get("url")
-            )
+
+            # Dry-run jobs never produce a results URL; skip extraction so we
+            # don't fall through to a None _results_url that would later crash
+            # in IonQClient.make_path().
+            if not self._dry_run:
+                _results_url = self._first_of(
+                    response, "results", "results_url", default={}
+                )
+                self._results_url = (
+                    _results_url
+                    if isinstance(_results_url, str)
+                    else _results_url.get("probabilities", {}).get("url")
+                )
 
             # Classical-bit maps per circuit
             def _meas_map_from_header(header_dict, fallback_nq):
                 """Return meas_mapped list or a default 0-based map."""
+                # Header may be missing entirely (e.g. for dry-run jobs that
+                # skip the qiskit metadata roundtrip); fall back to a 0..N map.
+                if not isinstance(header_dict, dict):
+                    return list(range(fallback_nq))
                 mmap = header_dict.get("meas_mapped")
                 if mmap is None or (
                     isinstance(mmap, list) and all(b is None for b in mmap)

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, patch
-VERSION_INFO = ".".join(map(str, (1, 0, 2)))
+VERSION_INFO = ".".join(map(str, (1, 0, 3)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -316,7 +316,7 @@ def test_backend_memory(
         job.get_memory()  # pylint: disable=no-member
 
 
-def test_run_dry_run_sets_top_level_field(mock_backend, requests_mock):
+def test_run_dry_run_sends_flag(mock_backend, requests_mock):
     """`backend.run(qc, dry_run=True)` must put `dry_run: true` at the top
     level of the request body. Compilation-as-a-service uses this to compile
     the circuit without executing it on the QPU."""
@@ -334,7 +334,7 @@ def test_run_dry_run_sets_top_level_field(mock_backend, requests_mock):
     assert request_json["dry_run"] is True
 
 
-def test_run_dry_run_default_is_omitted(mock_backend, requests_mock):
+def test_run_no_dry_run_omits_flag(mock_backend, requests_mock):
     """When `dry_run` is not supplied, the field must NOT be in the request
     body at all (so the API behaves identically to pre-1.x clients)."""
     path = mock_backend.client.make_path("jobs")
@@ -350,7 +350,7 @@ def test_run_dry_run_default_is_omitted(mock_backend, requests_mock):
     assert "dry_run" not in request_json
 
 
-def test_run_dry_run_via_extra_query_params_still_works(mock_backend, requests_mock):
+def test_dry_run_via_extra_params(mock_backend, requests_mock):
     """Back-compat: the pre-existing
     `extra_query_params={"dry_run": True}` workaround must keep working
     after the first-class kwarg is added."""

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -314,3 +314,54 @@ def test_backend_memory(
     job = ionq_job.IonQJob(mock_backend, job_id)
     with pytest.raises(AttributeError):
         job.get_memory()  # pylint: disable=no-member
+
+
+def test_run_dry_run_sets_top_level_field(mock_backend, requests_mock):
+    """`backend.run(qc, dry_run=True)` must put `dry_run: true` at the top
+    level of the request body. Compilation-as-a-service uses this to compile
+    the circuit without executing it on the QPU."""
+    path = mock_backend.client.make_path("jobs")
+    requests_mock.post(
+        path, json=conftest.dummy_job_response("fake_job"), status_code=200
+    )
+
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    mock_backend.run(qc, dry_run=True)
+
+    assert len(requests_mock.request_history) == 1
+    request_json = requests_mock.request_history[0].json()
+    assert request_json["dry_run"] is True
+
+
+def test_run_dry_run_default_is_omitted(mock_backend, requests_mock):
+    """When `dry_run` is not supplied, the field must NOT be in the request
+    body at all (so the API behaves identically to pre-1.x clients)."""
+    path = mock_backend.client.make_path("jobs")
+    requests_mock.post(
+        path, json=conftest.dummy_job_response("fake_job"), status_code=200
+    )
+
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    mock_backend.run(qc)
+
+    request_json = requests_mock.request_history[0].json()
+    assert "dry_run" not in request_json
+
+
+def test_run_dry_run_via_extra_query_params_still_works(mock_backend, requests_mock):
+    """Back-compat: the pre-existing
+    `extra_query_params={"dry_run": True}` workaround must keep working
+    after the first-class kwarg is added."""
+    path = mock_backend.client.make_path("jobs")
+    requests_mock.post(
+        path, json=conftest.dummy_job_response("fake_job"), status_code=200
+    )
+
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    mock_backend.run(qc, extra_query_params={"dry_run": True})
+
+    request_json = requests_mock.request_history[0].json()
+    assert request_json["dry_run"] is True

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -913,7 +913,7 @@ def _dry_run_job_response(job_id, target="qpu.forte-1"):
     }
 
 
-def test_dry_run_status_does_not_set_results_url(mock_backend, requests_mock):
+def test_dry_run_no_results_url(mock_backend, requests_mock):
     """Dry-run jobs should reach DONE without a results URL crash."""
     job_id = "dry_run_id"
     fetch_path = mock_backend.client.make_path("jobs", job_id)
@@ -927,7 +927,7 @@ def test_dry_run_status_does_not_set_results_url(mock_backend, requests_mock):
     assert job._results_url is None
 
 
-def test_dry_run_result_raises_friendly_error(mock_backend, requests_mock):
+def test_dry_run_result_raises(mock_backend, requests_mock):
     """Calling .result() on a dry-run job should raise a clear IonQJobError
     instead of the cryptic TypeError from passing None into make_path()."""
     job_id = "dry_run_id"
@@ -940,7 +940,7 @@ def test_dry_run_result_raises_friendly_error(mock_backend, requests_mock):
         job.result()
 
 
-def test_dry_run_compiled_circuit_native(mock_backend, requests_mock):
+def test_dry_run_compiled_native(mock_backend, requests_mock):
     """compiled_circuit(lang='native') hits /jobs/<id>/circuits/native and
     returns the JSON-decoded body as a string."""
     job_id = "dry_run_id"
@@ -949,7 +949,9 @@ def test_dry_run_compiled_circuit_native(mock_backend, requests_mock):
         json=_dry_run_job_response(job_id),
     )
 
-    native_body = '{"gateset":"native","circuit":[{"gate":"gpi2","target":0,"phase":0.0}]}'
+    native_body = (
+        '{"gateset":"native","circuit":[{"gate":"gpi2","target":0,"phase":0.0}]}'
+    )
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id, "circuits", "native"),
         json=native_body,
@@ -960,7 +962,7 @@ def test_dry_run_compiled_circuit_native(mock_backend, requests_mock):
     assert job.compiled_circuit(lang="native") == native_body
 
 
-def test_dry_run_compiled_circuit_qasm3(mock_backend, requests_mock):
+def test_dry_run_compiled_qasm3(mock_backend, requests_mock):
     """compiled_circuit(lang='qasm3') returns the OpenQASM 3 string."""
     job_id = "dry_run_id"
     requests_mock.get(
@@ -978,7 +980,7 @@ def test_dry_run_compiled_circuit_qasm3(mock_backend, requests_mock):
     assert job.compiled_circuit(lang="qasm3") == qasm3
 
 
-def test_compiled_circuit_rejects_bad_lang(mock_backend, requests_mock):
+def test_compiled_bad_lang(mock_backend, requests_mock):
     """Unknown lang values must raise ValueError before any HTTP call."""
     job_id = "dry_run_id"
     requests_mock.get(
@@ -990,7 +992,7 @@ def test_compiled_circuit_rejects_bad_lang(mock_backend, requests_mock):
         job.compiled_circuit(lang="qasm")  # qasm2 / qasm are NOT valid
 
 
-def test_dry_run_property_default_false(mock_backend, requests_mock):
+def test_dry_run_property_false(mock_backend, requests_mock):
     """A regular (non-dry-run) job exposes dry_run=False."""
     job_id = "regular_job"
     fetch_path = mock_backend.client.make_path("jobs", job_id)

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -874,3 +874,127 @@ def test_multi_circuit_clbit_map(mock_backend, requests_mock):
 
     job = ionq_job.IonQJob(mock_backend, job_id)
     assert job._clbits == meas_maps
+
+
+# ---------------------------------------------------------------------------
+# dry_run / compilation-as-a-service
+# ---------------------------------------------------------------------------
+
+
+def _dry_run_job_response(job_id, target="qpu.forte-1"):
+    """Mimic the API response for a completed dry-run job.
+
+    Per the v0.4 spec, the top-level ``dry_run`` boolean is echoed back, and
+    ``results`` is null because no measurement data is produced.
+    """
+    qiskit_header = compress_to_metadata_string(
+        {
+            "qubit_labels": [["q", 0], ["q", 1]],
+            "n_qubits": 2,
+            "qreg_sizes": [["q", 2]],
+            "clbit_labels": [["c", 0], ["c", 1]],
+            "memory_slots": 2,
+            "creg_sizes": [["c", 2]],
+            "name": job_id,
+            "global_phase": 0,
+        }
+    )
+    return {
+        "id": job_id,
+        "status": "completed",
+        "type": "ionq.circuit.v1",
+        "backend": target,
+        "dry_run": True,
+        "shots": 1024,
+        "metadata": {"qiskit_header": qiskit_header, "shots": "1024"},
+        "stats": {"qubits": 2, "circuits": 1},
+        # Per v0.4 spec, dry-run jobs have results=null.
+        "results": None,
+    }
+
+
+def test_dry_run_status_does_not_set_results_url(mock_backend, requests_mock):
+    """Dry-run jobs should reach DONE without a results URL crash."""
+    job_id = "dry_run_id"
+    fetch_path = mock_backend.client.make_path("jobs", job_id)
+    requests_mock.get(fetch_path, json=_dry_run_job_response(job_id))
+
+    # status() runs as part of __init__ when job_id is supplied
+    job = ionq_job.IonQJob(mock_backend, job_id)
+
+    assert job.status() == jobstatus.JobStatus.DONE
+    assert job.dry_run is True
+    assert job._results_url is None
+
+
+def test_dry_run_result_raises_friendly_error(mock_backend, requests_mock):
+    """Calling .result() on a dry-run job should raise a clear IonQJobError
+    instead of the cryptic TypeError from passing None into make_path()."""
+    job_id = "dry_run_id"
+    fetch_path = mock_backend.client.make_path("jobs", job_id)
+    requests_mock.get(fetch_path, json=_dry_run_job_response(job_id))
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+
+    with pytest.raises(exceptions.IonQJobError, match="dry_run=True"):
+        job.result()
+
+
+def test_dry_run_compiled_circuit_native(mock_backend, requests_mock):
+    """compiled_circuit(lang='native') hits /jobs/<id>/circuits/native and
+    returns the JSON-decoded body as a string."""
+    job_id = "dry_run_id"
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id),
+        json=_dry_run_job_response(job_id),
+    )
+
+    native_body = '{"gateset":"native","circuit":[{"gate":"gpi2","target":0,"phase":0.0}]}'
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id, "circuits", "native"),
+        json=native_body,
+    )
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    assert job.compiled_circuit() == native_body
+    assert job.compiled_circuit(lang="native") == native_body
+
+
+def test_dry_run_compiled_circuit_qasm3(mock_backend, requests_mock):
+    """compiled_circuit(lang='qasm3') returns the OpenQASM 3 string."""
+    job_id = "dry_run_id"
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id),
+        json=_dry_run_job_response(job_id),
+    )
+
+    qasm3 = "OPENQASM 3.0;\ngate gpi2(p) q { } // ...\n"
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id, "circuits", "qasm3"),
+        json=qasm3,
+    )
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    assert job.compiled_circuit(lang="qasm3") == qasm3
+
+
+def test_compiled_circuit_rejects_bad_lang(mock_backend, requests_mock):
+    """Unknown lang values must raise ValueError before any HTTP call."""
+    job_id = "dry_run_id"
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id),
+        json=_dry_run_job_response(job_id),
+    )
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    with pytest.raises(ValueError, match="lang must be"):
+        job.compiled_circuit(lang="qasm")  # qasm2 / qasm are NOT valid
+
+
+def test_dry_run_property_default_false(mock_backend, requests_mock):
+    """A regular (non-dry-run) job exposes dry_run=False."""
+    job_id = "regular_job"
+    fetch_path = mock_backend.client.make_path("jobs", job_id)
+    requests_mock.get(fetch_path, json=conftest.dummy_job_response(job_id))
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    assert job.dry_run is False

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -980,16 +980,47 @@ def test_dry_run_compiled_qasm3(mock_backend, requests_mock):
     assert job.compiled_circuit(lang="qasm3") == qasm3
 
 
-def test_compiled_bad_lang(mock_backend, requests_mock):
-    """Unknown lang values must raise ValueError before any HTTP call."""
+def test_compiled_lang_passthrough(mock_backend, requests_mock):
+    """Any string is forwarded to the API as-is.
+
+    The server is the source of truth for which lang values are accepted
+    and which are gated behind per-organization entitlement; the SDK does
+    not duplicate that policy. This test mocks the request URL with a
+    non-default lang and confirms it is reached.
+    """
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
         json=_dry_run_job_response(job_id),
     )
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id, "circuits", "future-lang"),
+        json="some-payload",
+    )
     job = ionq_job.IonQJob(mock_backend, job_id)
-    with pytest.raises(ValueError, match="lang must be"):
-        job.compiled_circuit(lang="qasm")  # qasm2 / qasm are NOT valid
+    assert job.compiled_circuit(lang="future-lang") == "some-payload"
+
+
+def test_compiled_lang_api_error(mock_backend, requests_mock):
+    """Server-side rejection of an unsupported / non-entitled lang surfaces
+    as IonQAPIError, matching every other non-2xx API response."""
+    job_id = "dry_run_id"
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id),
+        json=_dry_run_job_response(job_id),
+    )
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id, "circuits", "nope"),
+        status_code=403,
+        json={
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Organization does not have access to this compiled language",
+        },
+    )
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    with pytest.raises(exceptions.IonQAPIError):
+        job.compiled_circuit(lang="nope")
 
 
 def test_dry_run_property_false(mock_backend, requests_mock):


### PR DESCRIPTION
### Summary

Adds first-class support for IonQ Cloud's compilation-as-a-service flow: submit a job with `dry_run=True` and the API compiles the circuit without executing it on the QPU. The compiled circuit is then retrievable through the SDK in either IonQ-native JSON or OpenQASM 3.

### Details and comments

**Before this PR**, the only way to use compilation-as-a-service from `qiskit-ionq` was the untyped `extra_query_params={"dry_run": True}` escape hatch, and:

- Calling `job.result()` on a dry-run job crashed with `TypeError: sequence item 0: expected str instance, NoneType found` (because `results` is `null` in the API response, so `_results_url` ended up `None` and was passed straight into `IonQClient.make_path()`).
- The compiled circuit itself was unreachable through the SDK — users had to hit `GET /v0.4/jobs/{UUID}/circuits/{lang}` by hand.

**After this PR:**

```python
backend = provider.get_backend("ionq_qpu.forte-1")

job = backend.run(qc, dry_run=True)
job.wait_for_final_state()

native_json = job.compiled_circuit(lang="native")   # IonQ-native JSON
qasm3       = job.compiled_circuit(lang="qasm3")    # OpenQASM 3
```

**Changes**

- `IonQBackend._default_options()` gains `dry_run=False`; `backend.run(qc, dry_run=True)` sets the top-level `dry_run` field of the `ionq.circuit.v1` / `ionq.multi-circuit.v1` payload.
- `IonQJob.dry_run` property mirrors the API response.
- `IonQJob.compiled_circuit(lang="native"|"qasm3")` calls `GET /v0.4/jobs/{UUID}/circuits/{lang}` via a new `IonQClient.get_compiled_circuit(...)`. Invalid `lang` values raise `ValueError` before any HTTP call.
- `IonQJob.result()` now raises a clear `IonQJobError` on dry-run jobs ("...no measurement results are produced. Use `job.compiled_circuit(...)` instead.") rather than the cryptic `TypeError`.
- `IonQJob.status()` no longer attempts to extract `_results_url` for dry-run completes.
- Hardens `_meas_map_from_header` against missing/`None` `qiskit_header` entries (which dry-run jobs frequently lack).

**Back-compat**

The pre-existing `extra_query_params={"dry_run": True}` workaround keeps working unchanged — there's a regression test for it.

**Tests**

9 new tests covering: kwarg plumbing, default omission, the back-compat path, dry-run status without `_results_url`, the friendly `IonQJobError` from `result()`, both `lang="native"` and `lang="qasm3"` on `compiled_circuit()`, invalid `lang` rejection, and the `dry_run` property on regular jobs. **343 tests total, 0 regressions.**

**Docs**

New "Compilation as a service (`dry_run`)" section in the README under Provider Setup.

**API spec**

Matches v0.4 of `https://api.ionq.co/v0.4/api-docs`: `dry_run: boolean` is a top-level field on `CircuitJobCreationPayload` / `MultiCircuitJobCreationPayload` / `QuantumFunctionJobCreationPayload`, and `GET /jobs/{UUID}/circuits/{lang}` accepts `lang ∈ {"native", "qasm3"}` (no `qasm`/`qasm2`).

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
