### PR TITLE
Add ZZ as native 2q gate for Tempo-class backends

### DIFF
--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -78,6 +78,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from .ionq_provider import IonQProvider
 
 
+# Backend-name fragments whose native two-qubit gate is ZZ rather than MS.
+# Used by IonQBackend._make_target to pick the right entangler when building
+# the native-gateset Target. New ZZ-class backends should be appended here
+# until /backends exposes the native gate set per system.
+_ZZ_NATIVE_BACKENDS: tuple[str, ...] = ("forte", "tempo")
+
+
 class IonQBackend(Backend):
     """Common functionality for all IonQ backends (simulator and QPU)."""
 
@@ -321,8 +328,13 @@ class IonQBackend(Backend):
             for gate in (GPIGate(phi), GPI2Gate(phi)):
                 tgt.add_instruction(gate)
 
-            # 2q native
-            if "forte" in self.name.lower():
+            # 2q native: backend-dependent.
+            # ZZ-class systems (Forte, Tempo) use ZZGate; MS-class systems
+            # (Aria) use the parameterised MSGate. Driven by the backend
+            # name suffix because the API does not yet expose this in the
+            # /backends payload (tracked separately under the SDK topology
+            # work item).
+            if any(name in self.name.lower() for name in _ZZ_NATIVE_BACKENDS):
                 theta = Parameter("θ")
                 tgt.add_instruction(ZZGate(theta))
             else:

--- a/test/ionq_provider/test_backend_service.py
+++ b/test/ionq_provider/test_backend_service.py
@@ -25,6 +25,8 @@
 # limitations under the License.
 """Test basic provider API methods."""
 
+import pytest
+
 from qiskit_ionq import IonQProvider
 
 
@@ -60,3 +62,35 @@ def test_backend_eq():
     assert sub1 != sub2
     assert also_sub1 != sub2
     assert sub1 != simulator
+
+
+# ---------------------------------------------------------------------------
+# Native-gateset two-qubit instruction selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected_2q",
+    [
+        # ZZ-class
+        ("ionq_qpu.forte-1", "zz"),
+        ("ionq_qpu.forte-enterprise-1", "zz"),
+        ("ionq_qpu.tempo-1", "zz"),
+        # MS-class
+        ("ionq_qpu.aria-1", "ms"),
+        ("ionq_qpu.aria-2", "ms"),
+        # Generic / unrecognised falls back to MS, matching pre-existing behaviour
+        ("ionq_qpu.unknown-1", "ms"),
+    ],
+)
+def test_native_2q_gate(name, expected_2q):
+    """The native-gateset Target should expose ZZ on Forte/Tempo and MS on Aria."""
+    pro = IonQProvider("123456")
+    backend = pro.get_backend(name, gateset="native")
+    instr_names = set(backend.target.operation_names)
+    assert (
+        expected_2q in instr_names
+    ), f"{name}: expected {expected_2q!r} in target ops, got {instr_names}"
+    # And the *other* 2q native gate must NOT be present, to keep the Target unambiguous.
+    other = "ms" if expected_2q == "zz" else "zz"
+    assert other not in instr_names, f"{name}: unexpected {other!r} in target ops"


### PR DESCRIPTION
### Summary

`qpu.tempo-1` is now reachable via the `/v0.4` API but `qiskit-ionq` builds an `MS`-only `Target` for it, which misroutes the Qiskit transpiler. Tempo is a ZZ-class system; this PR fixes the native-gateset `Target` to expose `ZZGate` on Tempo (and on any future ZZ-class system) without changing behaviour for Aria.

### Details and comments

`IonQBackend._make_target` previously picked the entangler by substring-matching `"forte"` against the backend name:

```python
if "forte" in self.name.lower():
    tgt.add_instruction(ZZGate(theta))
else:
    tgt.add_instruction(MSGate(phi0, phi1, theta))
```

That branch silently sends every non-Forte QPU - including Tempo - down the MS path. Replaced with a small lookup tuple:

```python
_ZZ_NATIVE_BACKENDS: tuple[str, ...] = ("forte", "tempo")
...
if any(name in self.name.lower() for name in _ZZ_NATIVE_BACKENDS):
    tgt.add_instruction(ZZGate(theta))
else:
    tgt.add_instruction(MSGate(phi0, phi1, theta))
```

Future ZZ-class systems are a one-line addition.

**Why a static list instead of reading from `/backends`:** the `/v0.4/backends/<name>` payload doesn't yet expose the system's native gate set; until it does (tracked separately as part of the SDK topology work), name-based dispatch is the smallest correct fix.

**Tests:** parameterised over Forte, Forte Enterprise, and Tempo (expect `zz`); Aria-1 and Aria-2 (expect `ms`); plus an unrecognised name (falls back to `ms`, matching pre-existing behaviour).

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
