### PR TITLE
Surface settings.compilation via a compilation= kwarg

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ qasm3       = job.compiled_circuit(lang="qasm3")    # OpenQASM 3
 
 Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
 
+Compilation-side knobs (compiler version, optimisation level, output basis, precision) are forwarded to the API's `settings.compilation` block via a `compilation=` kwarg:
+
+```python
+job = backend.run(
+    qc,
+    dry_run=True,
+    compilation={"service_version": "v2", "opt": 0.7, "gate_basis": "native"},
+)
+```
+
+Fields are passed through verbatim; refer to the IonQ API reference for the supported values.
+
 ### Basis gates and transpilation
 
 The IonQ provider provides access to the full IonQ Cloud backend, which includes its own transpilation and compilation pipeline. As such, IonQ provider backends have a broad set of "basis gates" that they will accept — effectively anything the IonQ API will accept. The current supported gates can be found [on our docs site](https://docs.ionq.com/#tag/quantum_programs).

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -549,6 +549,16 @@ def qiskit_to_ionq(
     if isinstance(error_mitigation, ErrorMitigation):
         settings["error_mitigation"] = error_mitigation.value
 
+    # Compilation settings: explicit `compilation=` kwarg wins over anything
+    # the user may have placed under job_settings["compilation"]. Merged
+    # shallowly so callers can override individual fields without restating
+    # the whole block.
+    compilation = passed_args.get("compilation")
+    if compilation:
+        existing = dict(settings.get("compilation") or {})
+        existing.update(compilation)
+        settings["compilation"] = existing
+
     if settings:
         ionq_json["settings"] = settings
 

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -138,6 +138,7 @@ class IonQBackend(Backend):
             sampler_seed=None,  # simulator-only (harmless on QPU)
             noise_model="ideal",  # simulator-only
             dry_run=False,  # if True, the API compiles but does not execute
+            compilation=None,  # forwarded to settings.compilation block
         )
 
     @property

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -365,3 +365,74 @@ def test_dry_run_via_extra_params(mock_backend, requests_mock):
 
     request_json = requests_mock.request_history[0].json()
     assert request_json["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# Compilation settings (`compilation=` kwarg -> settings.compilation block)
+# ---------------------------------------------------------------------------
+
+
+def test_run_compilation_kwarg(mock_backend, requests_mock):
+    """`backend.run(qc, compilation={...})` must end up at settings.compilation
+    in the API request body."""
+    path = mock_backend.client.make_path("jobs")
+    requests_mock.post(
+        path, json=conftest.dummy_job_response("fake_job"), status_code=200
+    )
+
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    mock_backend.run(
+        qc,
+        compilation={
+            "service_version": "v2",
+            "opt": 0.5,
+            "precision": "high",
+            "gate_basis": "native",
+        },
+    )
+
+    body = requests_mock.request_history[0].json()
+    assert body["settings"]["compilation"] == {
+        "service_version": "v2",
+        "opt": 0.5,
+        "precision": "high",
+        "gate_basis": "native",
+    }
+
+
+def test_run_no_compilation_omits(mock_backend, requests_mock):
+    """When no compilation kwarg is passed, the settings block should not
+    contain a compilation entry (so we don't shadow server-side defaults)."""
+    path = mock_backend.client.make_path("jobs")
+    requests_mock.post(
+        path, json=conftest.dummy_job_response("fake_job"), status_code=200
+    )
+
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    mock_backend.run(qc)
+
+    body = requests_mock.request_history[0].json()
+    assert "compilation" not in body.get("settings", {})
+
+
+def test_compilation_overrides(mock_backend, requests_mock):
+    """If the user passes both job_settings={'compilation': {...}} and the
+    explicit compilation kwarg, the kwarg wins for overlapping keys, while
+    non-overlapping keys from job_settings are preserved."""
+    path = mock_backend.client.make_path("jobs")
+    requests_mock.post(
+        path, json=conftest.dummy_job_response("fake_job"), status_code=200
+    )
+
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    mock_backend.run(
+        qc,
+        job_settings={"compilation": {"opt": 0.1, "precision": "low"}},
+        compilation={"opt": 0.9},
+    )
+
+    compilation = requests_mock.request_history[0].json()["settings"]["compilation"]
+    assert compilation == {"opt": 0.9, "precision": "low"}


### PR DESCRIPTION
### Summary

The `/v0.4` job-creation payload accepts a `settings.compilation` object with fields like `opt`, `precision`, `gate_basis`, and `service_version`, but qiskit-ionq has only ever forwarded `settings.error_mitigation`. Users hitting compile-as-a-service workflows have had no first-class way to pin a compiler version or tweak compilation settings short of `extra_query_params` (untyped) or `job_settings` (undocumented for this purpose).

Add a `compilation=` kwarg on `backend.run(...)`.

### Details and comments

```python
job = backend.run(
    qc,
    dry_run=True,
    compilation={"service_version": "v2", "opt": 0.7, "gate_basis": "native"},
)
```

The dict lands verbatim at `settings.compilation` in the request body.

**Merging behaviour.** If the user passes both `job_settings={"compilation": {...}}` and `compilation={...}`, the explicit `compilation=` kwarg wins for overlapping keys; non-overlapping entries from `job_settings` are preserved (shallow merge):

```python
backend.run(
    qc,
    job_settings={"compilation": {"opt": 0.1, "precision": "low"}},
    compilation={"opt": 0.9},
)
# -> settings.compilation == {"opt": 0.9, "precision": "low"}
```

**Pass-through, not validation.** Fields are forwarded as-is; the API does the validation. This lets new compilation settings flow through without an SDK release.

**Tests:** kwarg populates `settings.compilation`, omitted by default (so we don't shadow server-side defaults), and kwarg overrides overlapping `job_settings` keys while preserving non-overlapping ones.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
