### PR TITLE
Add IonQJob.compiled_qiskit_circuit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ qasm3       = job.compiled_circuit(lang="qasm3")    # OpenQASM 3
 
 Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
 
+For `lang="qasm3"` you can also call `job.compiled_qiskit_circuit()` to get the result back as a Qiskit `QuantumCircuit` ready for inspection, drawing, or further composition:
+
+```python
+qc_compiled = job.compiled_qiskit_circuit()
+qc_compiled.draw("text")
+qc_compiled.count_ops()
+```
+
 ### Basis gates and transpilation
 
 The IonQ provider provides access to the full IonQ Cloud backend, which includes its own transpilation and compilation pipeline. As such, IonQ provider backends have a broad set of "basis gates" that they will accept — effectively anything the IonQ API will accept. The current supported gates can be found [on our docs site](https://docs.ionq.com/#tag/quantum_programs).

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -247,6 +247,41 @@ class IonQJob(JobV1):
         assert self._job_id is not None
         return self._client.get_compiled_circuit(self._job_id, lang=lang)
 
+    def compiled_qiskit_circuit(self) -> QuantumCircuit:
+        """Return the server-compiled circuit as a Qiskit ``QuantumCircuit``.
+
+        Convenience wrapper over :meth:`compiled_circuit` that fetches the
+        OpenQASM 3 representation of the compiled program and parses it back
+        into a ``QuantumCircuit``, so the user can inspect, draw, count gates,
+        or compose with other Qiskit objects.
+
+        Raises:
+            IonQJobStateError: If the job has not reached a final state yet.
+            IonQJobFailureError: If the job failed before compilation completed.
+            IonQJobError: If the API returned text the Qiskit OpenQASM 3
+                importer cannot parse (typically because the compiled output
+                uses gate declarations Qiskit's parser does not recognise).
+                Use :meth:`compiled_circuit` with ``lang="qasm3"`` to get the
+                raw text in that case.
+
+        Returns:
+            QuantumCircuit: The compiled circuit, parsed from QASM 3.
+        """
+        # Imported here rather than at module load so the qasm3 importer is
+        # only paid for when this method is actually called.
+        from qiskit.qasm3 import loads as _qasm3_loads, QASM3ImporterError
+        from openqasm3.parser import QASM3ParsingError
+
+        qasm3_text = self.compiled_circuit(lang="qasm3")
+        try:
+            return _qasm3_loads(qasm3_text)
+        except (QASM3ImporterError, QASM3ParsingError) as exc:
+            raise exceptions.IonQJobError(
+                f"Could not parse compiled QASM 3 for job {self._job_id} into a "
+                "QuantumCircuit. Use job.compiled_circuit(lang='qasm3') to get "
+                f"the raw text. Underlying error: {exc}"
+            ) from exc
+
     def cancel(self) -> None:
         """Cancel this job."""
         assert self._job_id is not None, "Cannot cancel a job without a job_id."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=2.0.0
+qiskit[qasm3-import]>=2.0.0
 decorator>=5.1.0
 requests>=2.24.0
 importlib-metadata>=4.11.4

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1000,3 +1000,61 @@ def test_dry_run_property_false(mock_backend, requests_mock):
 
     job = ionq_job.IonQJob(mock_backend, job_id)
     assert job.dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# compiled_qiskit_circuit (QASM 3 -> QuantumCircuit)
+# ---------------------------------------------------------------------------
+
+_QASM3_BELL = """OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q;
+bit[2] c;
+h q[0];
+cx q[0], q[1];
+c[0] = measure q[0];
+c[1] = measure q[1];
+"""
+
+
+def test_compiled_qiskit_circuit(mock_backend, requests_mock):
+    """compiled_qiskit_circuit() should fetch QASM 3 and parse it into a
+    Qiskit QuantumCircuit ready for further inspection."""
+    job_id = "dry_run_id"
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id),
+        json=_dry_run_job_response(job_id),
+    )
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id, "circuits", "qasm3"),
+        json=_QASM3_BELL,
+    )
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    qc = job.compiled_qiskit_circuit()
+
+    # Round-trip sanity: type is QuantumCircuit, gates are recognisable.
+    assert isinstance(qc, QuantumCircuit)
+    assert qc.num_qubits == 2
+    ops = qc.count_ops()
+    assert ops.get("h") == 1
+    assert ops.get("cx") == 1
+    assert ops.get("measure") == 2
+
+
+def test_compiled_qc_unparseable(mock_backend, requests_mock):
+    """If the API returns text the QASM 3 importer cannot parse, the user
+    should get a clear IonQJobError pointing back to compiled_circuit()."""
+    job_id = "dry_run_id"
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id),
+        json=_dry_run_job_response(job_id),
+    )
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id, "circuits", "qasm3"),
+        json="this is not openqasm",
+    )
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    with pytest.raises(exceptions.IonQJobError, match="QASM 3"):
+        job.compiled_qiskit_circuit()


### PR DESCRIPTION
### Summary

Add `IonQJob.compiled_qiskit_circuit()` so users can get the server-compiled circuit back as a Qiskit `QuantumCircuit` directly, ready for inspection / drawing / gate-counting / composition. Closes the third leg of the compilation-as-a-service workflow that landed in #246:

```python
job = backend.run(qc, dry_run=True)
job.wait_for_final_state()
qc_compiled = job.compiled_qiskit_circuit()
qc_compiled.draw("text")
qc_compiled.count_ops()
```

### Details and comments

The Qiskit OpenQASM 3 importer is the right primitive for this — it parses the `lang="qasm3"` text returned by `GET /v0.4/jobs/{id}/circuits/qasm3` into a `QuantumCircuit`. The importer ships behind `qiskit[qasm3-import]`. Promoted to a hard requirement in `requirements.txt` rather than maintaining a parallel extra in `setup.py`:

- Keeps installation a single `pip install qiskit-ionq` for everyone.
- Lets Qiskit own the version pin (no second pin to drift).
- Removes a missing-library error branch and an `ImportError` fallback from the implementation - the method's body is now ~12 lines.

**Error handling.** The Qiskit importer wraps semantic-translation failures in `QASM3ImporterError`, but raw OpenQASM 3 parser failures bubble through as `openqasm3.parser.QASM3ParsingError`. Both are caught and re-raised as `IonQJobError` pointing the user at `compiled_circuit(lang="qasm3")` for the raw text.

**Tests.** Round-trip a Bell-prep QASM 3 program (asserts `num_qubits`, `count_ops()` for `h`, `cx`, and `measure`); unparseable text raises `IonQJobError`.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
