### PR TITLE
Fix SparseObservable compatibility

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -275,12 +275,17 @@ def qiskit_circ_to_ionq_circ(
             )
 
         if instruction_name == "pauliexp":
+            operator = instruction.operator
+            # Patch for Qiskit 1.2+: Convert SparseObservable to SparsePauliOp
+            if not hasattr(operator, "to_list"):
+                from qiskit.quantum_info import SparsePauliOp
+                operator = SparsePauliOp.from_sparse_observable(operator)
             imag_coeff = any(coeff.imag for coeff in instruction.operator.coeffs)
             assert not imag_coeff, (
                 "PauliEvolution gate must have real coefficients, "
                 f"but got {imag_coeff}"
             )
-            terms = [term[0] for term in instruction.operator.to_list()]
+            terms = [term[0] for term in operator.to_list()]
             if not ionq_compiler_synthesis and not paulis_commute(terms):
                 raise ionq_exceptions.IonQPauliExponentialError(
                     f"You have included a PauliEvolutionGate with non-commuting terms: {terms}."

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -53,6 +53,7 @@ from qiskit.circuit import (
     QuantumRegister,
     ClassicalRegister,
 )
+from qiskit.quantum_info import SparsePauliOp
 
 # Use this to get version instead of __version__ to avoid circular dependency.
 from importlib_metadata import version
@@ -277,8 +278,6 @@ def qiskit_circ_to_ionq_circ(
         if instruction_name == "pauliexp":
             operator = instruction.operator
             if not hasattr(operator, "to_list"):
-                from qiskit.quantum_info import SparsePauliOp
-
                 operator = SparsePauliOp.from_sparse_observable(operator)
             imag_coeff = any(coeff.imag for coeff in operator.coeffs)
             assert not imag_coeff, (

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -280,7 +280,7 @@ def qiskit_circ_to_ionq_circ(
             if not hasattr(operator, "to_list"):
                 from qiskit.quantum_info import SparsePauliOp
                 operator = SparsePauliOp.from_sparse_observable(operator)
-            imag_coeff = any(coeff.imag for coeff in instruction.operator.coeffs)
+            imag_coeff = any(coeff.imag for coeff in operator.coeffs)
             assert not imag_coeff, (
                 "PauliEvolution gate must have real coefficients, "
                 f"but got {imag_coeff}"
@@ -296,7 +296,7 @@ def qiskit_circ_to_ionq_circ(
                 input_circuit.qubits.index(qargs[i])
                 for i in range(instruction.num_qubits)
             ]
-            coefficients = [coeff.real for coeff in instruction.operator.coeffs]
+            coefficients = [coeff.real for coeff in operator.coeffs]
             gate = {
                 "gate": instruction_name,
                 "targets": targets,

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -276,9 +276,9 @@ def qiskit_circ_to_ionq_circ(
 
         if instruction_name == "pauliexp":
             operator = instruction.operator
-            # Patch for Qiskit 1.2+: Convert SparseObservable to SparsePauliOp
             if not hasattr(operator, "to_list"):
                 from qiskit.quantum_info import SparsePauliOp
+
                 operator = SparsePauliOp.from_sparse_observable(operator)
             imag_coeff = any(coeff.imag for coeff in operator.coeffs)
             assert not imag_coeff, (

--- a/test/helpers/test_gate_serialization.py
+++ b/test/helpers/test_gate_serialization.py
@@ -36,7 +36,7 @@ from qiskit.circuit import (
     Parameter,
 )
 from qiskit.circuit.library import PauliEvolutionGate
-from qiskit.quantum_info import SparsePauliOp
+from qiskit.quantum_info import SparsePauliOp, SparseObservable
 
 from qiskit_ionq import exceptions
 from qiskit_ionq.helpers import qiskit_circ_to_ionq_circ
@@ -226,6 +226,27 @@ def test_pauliexp_circuit():
     """Test structure of circuits with a Pauli evolution gate."""
     # build the evolution gate
     operator = SparsePauliOp(["XX", "YY", "ZZ"], coeffs=[0.1, 0.2, 0.3])
+    evo = PauliEvolutionGate(operator, time=0.4)
+    # append it to a circuit
+    circuit = QuantumCircuit(3)
+    circuit.append(evo, [1, 2])
+    expected = [
+        {
+            "gate": "pauliexp",
+            "targets": [1, 2],
+            "terms": ["XX", "YY", "ZZ"],
+            "coefficients": [0.1, 0.2, 0.3],
+            "time": 0.4,
+        }
+    ]
+    built, _, _ = qiskit_circ_to_ionq_circ(circuit)
+    assert built == expected
+    
+
+def test_pauliexp_circuit_sparse_observable():
+    """Test structure of circuits with a Pauli evolution gate built from SparseObservable."""
+    # build the evolution gate directly from SparseObservable
+    operator = SparseObservable.from_list([("XX", 0.1), ("YY", 0.2), ("ZZ", 0.3)])
     evo = PauliEvolutionGate(operator, time=0.4)
     # append it to a circuit
     circuit = QuantumCircuit(3)

--- a/test/helpers/test_gate_serialization.py
+++ b/test/helpers/test_gate_serialization.py
@@ -241,7 +241,7 @@ def test_pauliexp_circuit():
     ]
     built, _, _ = qiskit_circ_to_ionq_circ(circuit)
     assert built == expected
-    
+
 
 def test_pauliexp_circuit_sparse_observable():
     """Test structure of circuits with a Pauli evolution gate built from SparseObservable."""
@@ -257,6 +257,25 @@ def test_pauliexp_circuit_sparse_observable():
             "targets": [1, 2],
             "terms": ["XX", "YY", "ZZ"],
             "coefficients": [0.1, 0.2, 0.3],
+            "time": 0.4,
+        }
+    ]
+    built, _, _ = qiskit_circ_to_ionq_circ(circuit)
+    assert built == expected
+
+
+def test_pauliexp_sparse_observable_expand():
+    """Projector terms in a SparseObservable expand; coeff/term lengths must stay aligned."""
+    operator = SparseObservable.from_list([("+I", 0.7), ("XX", 0.5)])
+    evo = PauliEvolutionGate(operator, time=0.4)
+    circuit = QuantumCircuit(2)
+    circuit.append(evo, [0, 1])
+    expected = [
+        {
+            "gate": "pauliexp",
+            "targets": [0, 1],
+            "terms": ["II", "XI", "XX"],
+            "coefficients": [0.35, 0.35, 0.5],
             "time": 0.4,
         }
     ]


### PR DESCRIPTION
### Summary
Resolves an `AttributeError` caused by Qiskit versions introducing `SparseObservable` as the default `operator` in the `PauliEvolutionGate`, which lacks the `.to_list()` method. Implemented a check and used `SparsePauliOp.from_sparse_observable()` to cast the operator for backwards compatibility.

### Details and comments
More details in [Issue 250](https://github.com/qiskit-community/qiskit-ionq/issues/250)