### PR TITLE
Tempo: ZZ native gate, compilation= kwarg, compiled_circuit() → QuantumCircuit

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ print(job.result().get_probabilities())
 
 IonQ Cloud can compile a circuit and return the result _without_ executing it on a QPU. This is useful for inspecting the post-compilation circuit, estimating gate counts, or validating native-gate output before paying for shots.
 
-Set `dry_run=True` on `backend.run(...)` and then read the compiled circuit back via `job.compiled_circuit(...)`:
+Set `dry_run=True` on `backend.run(...)` and then read the compiled circuit back via `job.compiled_circuit()` (Qiskit `QuantumCircuit`) or `job.compiled_circuit_text(...)` (raw string in the chosen format):
 
 ```python
 backend = provider.get_backend("ionq_qpu.forte-1")
@@ -100,21 +100,17 @@ backend = provider.get_backend("ionq_qpu.forte-1")
 job = backend.run(qc, dry_run=True)
 job.wait_for_final_state()
 
-native_json = job.compiled_circuit(lang="native")   # IonQ-native JSON
-qasm3       = job.compiled_circuit(lang="qasm3")    # OpenQASM 3
-```
-
-Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
-
-For `lang="qasm3"` you can also call `job.compiled_qiskit_circuit()` to get the result back as a Qiskit `QuantumCircuit` ready for inspection, drawing, or further composition:
-
-```python
-qc_compiled = job.compiled_qiskit_circuit()
+qc_compiled = job.compiled_circuit()                     # QuantumCircuit (from QASM 3)
 qc_compiled.draw("text")
 qc_compiled.count_ops()
+
+native_json = job.compiled_circuit_text(lang="native")   # IonQ-native JSON
+qasm3       = job.compiled_circuit_text(lang="qasm3")    # OpenQASM 3
 ```
 
-Compilation-side knobs (compiler version, optimisation level, output basis, precision) are forwarded to the API's `settings.compilation` block via a `compilation=` kwarg:
+Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit()` / `compiled_circuit_text(...)`.
+
+Compilation knobs (compiler version, optimisation level, output basis, precision) are forwarded to the API's `settings.compilation` block via a `compilation=` kwarg:
 
 ```python
 job = backend.run(
@@ -124,7 +120,7 @@ job = backend.run(
 )
 ```
 
-Fields are passed through verbatim; refer to the IonQ API reference for the supported values.
+Fields are passed through verbatim; refer to the [IonQ API reference](https://docs.ionq.com/api-reference/v0.4/jobs/create-job) for the supported values. When both `compilation=` and `job_settings={"compilation": {...}}` are passed, the explicit `compilation=` kwarg wins on overlapping keys; non-overlapping keys from `job_settings` are preserved.
 
 ### Basis gates and transpilation
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ qasm3       = job.compiled_circuit(lang="qasm3")    # OpenQASM 3
 
 Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
 
+Compilation-side knobs (compiler version, optimisation level, output basis, precision) are forwarded to the API's `settings.compilation` block via a `compilation=` kwarg:
+
+```python
+job = backend.run(
+    qc,
+    dry_run=True,
+    compilation={"service_version": "v2", "opt": 0.7, "gate_basis": "native"},
+)
+```
+
+Fields are passed through verbatim; refer to the IonQ API reference for the supported values.
+
 ### Basis gates and transpilation
 
 The IonQ provider provides access to the full IonQ Cloud backend, which includes its own transpilation and compilation pipeline. As such, IonQ provider backends have a broad set of "basis gates" that they will accept — effectively anything the IonQ API will accept. The current supported gates can be found [on our docs site](https://docs.ionq.com/#tag/quantum_programs).

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ qasm3       = job.compiled_circuit(lang="qasm3")    # OpenQASM 3
 
 Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
 
+For `lang="qasm3"` you can also call `job.compiled_qiskit_circuit()` to get the result back as a Qiskit `QuantumCircuit` ready for inspection, drawing, or further composition:
+
+```python
+qc_compiled = job.compiled_qiskit_circuit()
+qc_compiled.draw("text")
+qc_compiled.count_ops()
+```
+
 Compilation-side knobs (compiler version, optimisation level, output basis, precision) are forwarded to the API's `settings.compilation` block via a `compilation=` kwarg:
 
 ```python

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -574,6 +574,16 @@ def qiskit_to_ionq(
     if isinstance(error_mitigation, ErrorMitigation):
         settings["error_mitigation"] = error_mitigation.value
 
+    # Compilation settings: explicit `compilation=` kwarg wins over anything
+    # the user may have placed under job_settings["compilation"]. Merged
+    # shallowly so callers can override individual fields without restating
+    # the whole block.
+    compilation = passed_args.get("compilation")
+    if compilation:
+        existing = dict(settings.get("compilation") or {})
+        existing.update(compilation)
+        settings["compilation"] = existing
+
     if settings:
         ionq_json["settings"] = settings
 

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -143,6 +143,7 @@ GATESET_MAP = {
 NATIVE_2Q_BY_FAMILY: dict[str, Literal["ms", "zz"]] = {
     "aria": "ms",
     "forte": "zz",
+    "tempo": "zz",
 }
 
 

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -329,7 +329,11 @@ class IonQBackend(Backend):
             for gate in (GPIGate(phi), GPI2Gate(phi)):
                 tgt.add_instruction(gate)
 
-            # 2q native: per family (see helpers.NATIVE_2Q_BY_FAMILY).
+            # 2q native: per family (see helpers.NATIVE_2Q_BY_FAMILY). Driven
+            # by backend name / noise_model because the API does not yet
+            # expose the native 2q gate in the /backends payload.
+            # TODO: drop the name-suffix dispatch once the SDK topology work
+            # item lands a `native_2q_gate` field on the /backends response.
             gate = (
                 native_2q_gate(self.name)
                 or native_2q_gate(getattr(self.options, "noise_model", None))

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -140,6 +140,7 @@ class IonQBackend(Backend):
             sampler_seed=None,  # simulator-only (harmless on QPU)
             noise_model="ideal",  # simulator-only
             dry_run=False,  # if True, the API compiles but does not execute
+            compilation=None,  # forwarded to settings.compilation block
         )
 
     @property

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -212,17 +212,21 @@ class IonQJob(JobV1):
 
         Dry-run jobs are compiled by the IonQ Cloud compiler-as-a-service but
         not executed - they produce no measurement results. Use
-        :meth:`compiled_circuit` to retrieve the compiled circuit instead of
-        :meth:`result`.
+        :meth:`compiled_circuit` (or :meth:`compiled_circuit_text` for the raw
+        IonQ-native JSON / OpenQASM 3 text) to retrieve the compiled circuit
+        instead of :meth:`result`.
         """
         return self._dry_run
 
-    def compiled_circuit(self, lang: str = "native") -> str:
-        """Fetch the server-compiled circuit for this job.
+    def compiled_circuit_text(self, lang: str = "native") -> str:
+        """Fetch the server-compiled circuit as a string in the chosen format.
 
         Useful for jobs submitted with ``dry_run=True`` (compilation as a
         service) but also works for any completed job to inspect what was
         actually run on hardware after IonQ's compiler resynthesizes the input.
+
+        For a parsed Qiskit ``QuantumCircuit`` instead of raw text, call
+        :meth:`compiled_circuit` (no args).
 
         Args:
             lang (str): Output language. ``"native"`` (default) returns the
@@ -251,13 +255,15 @@ class IonQJob(JobV1):
         assert self._job_id is not None
         return self._client.get_compiled_circuit(self._job_id, lang=lang)
 
-    def compiled_qiskit_circuit(self) -> QuantumCircuit:
+    def compiled_circuit(self) -> QuantumCircuit:
         """Return the server-compiled circuit as a Qiskit ``QuantumCircuit``.
 
-        Convenience wrapper over :meth:`compiled_circuit` that fetches the
-        OpenQASM 3 representation of the compiled program and parses it back
-        into a ``QuantumCircuit``, so the user can inspect, draw, count gates,
-        or compose with other Qiskit objects.
+        Fetches the OpenQASM 3 representation of the compiled program and
+        parses it back into a ``QuantumCircuit``, so the user can inspect,
+        draw, count gates, or compose with other Qiskit objects.
+
+        For the raw IonQ-native JSON or OpenQASM 3 text (e.g. to feed into
+        another tool), use :meth:`compiled_circuit_text`.
 
         Raises:
             IonQJobStateError: If the job has not reached a final state yet.
@@ -265,8 +271,8 @@ class IonQJob(JobV1):
             IonQJobError: If the API returned text the Qiskit OpenQASM 3
                 importer cannot parse (typically because the compiled output
                 uses gate declarations Qiskit's parser does not recognise).
-                Use :meth:`compiled_circuit` with ``lang="qasm3"`` to get the
-                raw text in that case.
+                Fall back to :meth:`compiled_circuit_text` with
+                ``lang="qasm3"`` to inspect the raw text in that case.
 
         Returns:
             QuantumCircuit: The compiled circuit, parsed from QASM 3.
@@ -276,14 +282,14 @@ class IonQJob(JobV1):
         from qiskit.qasm3 import loads as _qasm3_loads, QASM3ImporterError
         from openqasm3.parser import QASM3ParsingError
 
-        qasm3_text = self.compiled_circuit(lang="qasm3")
+        qasm3_text = self.compiled_circuit_text(lang="qasm3")
         try:
             return _qasm3_loads(qasm3_text)
         except (QASM3ImporterError, QASM3ParsingError) as exc:
             raise exceptions.IonQJobError(
                 f"Could not parse compiled QASM 3 for job {self._job_id} into a "
-                "QuantumCircuit. Use job.compiled_circuit(lang='qasm3') to get "
-                f"the raw text. Underlying error: {exc}"
+                "QuantumCircuit. Use job.compiled_circuit_text(lang='qasm3') "
+                f"to get the raw text. Underlying error: {exc}"
             ) from exc
 
     def cancel(self) -> None:
@@ -394,8 +400,9 @@ class IonQJob(JobV1):
                 raise exceptions.IonQJobError(
                     f"Job {self._job_id} was submitted with dry_run=True; "
                     "no measurement results are produced. Use "
-                    "job.compiled_circuit(lang='native' or 'qasm3') to "
-                    "retrieve the compiled circuit instead."
+                    "job.compiled_circuit() for a Qiskit QuantumCircuit, or "
+                    "job.compiled_circuit_text(lang='native' or 'qasm3') "
+                    "for the raw text, to retrieve the compiled circuit."
                 )
             response = self._client.get_results(
                 results_url=self._results_url,

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -251,6 +251,41 @@ class IonQJob(JobV1):
         assert self._job_id is not None
         return self._client.get_compiled_circuit(self._job_id, lang=lang)
 
+    def compiled_qiskit_circuit(self) -> QuantumCircuit:
+        """Return the server-compiled circuit as a Qiskit ``QuantumCircuit``.
+
+        Convenience wrapper over :meth:`compiled_circuit` that fetches the
+        OpenQASM 3 representation of the compiled program and parses it back
+        into a ``QuantumCircuit``, so the user can inspect, draw, count gates,
+        or compose with other Qiskit objects.
+
+        Raises:
+            IonQJobStateError: If the job has not reached a final state yet.
+            IonQJobFailureError: If the job failed before compilation completed.
+            IonQJobError: If the API returned text the Qiskit OpenQASM 3
+                importer cannot parse (typically because the compiled output
+                uses gate declarations Qiskit's parser does not recognise).
+                Use :meth:`compiled_circuit` with ``lang="qasm3"`` to get the
+                raw text in that case.
+
+        Returns:
+            QuantumCircuit: The compiled circuit, parsed from QASM 3.
+        """
+        # Imported here rather than at module load so the qasm3 importer is
+        # only paid for when this method is actually called.
+        from qiskit.qasm3 import loads as _qasm3_loads, QASM3ImporterError
+        from openqasm3.parser import QASM3ParsingError
+
+        qasm3_text = self.compiled_circuit(lang="qasm3")
+        try:
+            return _qasm3_loads(qasm3_text)
+        except (QASM3ImporterError, QASM3ParsingError) as exc:
+            raise exceptions.IonQJobError(
+                f"Could not parse compiled QASM 3 for job {self._job_id} into a "
+                "QuantumCircuit. Use job.compiled_circuit(lang='qasm3') to get "
+                f"the raw text. Underlying error: {exc}"
+            ) from exc
+
     def cancel(self) -> None:
         """Cancel this job."""
         assert self._job_id is not None, "Cannot cancel a job without a job_id."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=2.0.0
+qiskit[qasm3-import]>=2.0.0
 decorator>=5.1.0
 requests>=2.24.0
 importlib-metadata>=4.11.4

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -409,3 +409,74 @@ def test_forte_rzz_transpiles_to_zz(provider):
 
     assert "zz" in ops
     assert "ms" not in ops
+
+
+# ---------------------------------------------------------------------------
+# Compilation settings (`compilation=` kwarg -> settings.compilation block)
+# ---------------------------------------------------------------------------
+
+
+def test_run_compilation_kwarg(mock_backend, requests_mock):
+    """`backend.run(qc, compilation={...})` must end up at settings.compilation
+    in the API request body."""
+    path = mock_backend.client.make_path("jobs")
+    requests_mock.post(
+        path, json=conftest.dummy_job_response("fake_job"), status_code=200
+    )
+
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    mock_backend.run(
+        qc,
+        compilation={
+            "service_version": "v2",
+            "opt": 0.5,
+            "precision": "high",
+            "gate_basis": "native",
+        },
+    )
+
+    body = requests_mock.request_history[0].json()
+    assert body["settings"]["compilation"] == {
+        "service_version": "v2",
+        "opt": 0.5,
+        "precision": "high",
+        "gate_basis": "native",
+    }
+
+
+def test_run_no_compilation_omits(mock_backend, requests_mock):
+    """When no compilation kwarg is passed, the settings block should not
+    contain a compilation entry (so we don't shadow server-side defaults)."""
+    path = mock_backend.client.make_path("jobs")
+    requests_mock.post(
+        path, json=conftest.dummy_job_response("fake_job"), status_code=200
+    )
+
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    mock_backend.run(qc)
+
+    body = requests_mock.request_history[0].json()
+    assert "compilation" not in body.get("settings", {})
+
+
+def test_compilation_overrides(mock_backend, requests_mock):
+    """If the user passes both job_settings={'compilation': {...}} and the
+    explicit compilation kwarg, the kwarg wins for overlapping keys, while
+    non-overlapping keys from job_settings are preserved."""
+    path = mock_backend.client.make_path("jobs")
+    requests_mock.post(
+        path, json=conftest.dummy_job_response("fake_job"), status_code=200
+    )
+
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+    mock_backend.run(
+        qc,
+        job_settings={"compilation": {"opt": 0.1, "precision": "low"}},
+        compilation={"opt": 0.9},
+    )
+
+    compilation = requests_mock.request_history[0].json()["settings"]["compilation"]
+    assert compilation == {"opt": 0.9, "precision": "low"}

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -941,8 +941,8 @@ def test_dry_run_result_raises(mock_backend, requests_mock):
 
 
 def test_dry_run_compiled_native(mock_backend, requests_mock):
-    """compiled_circuit(lang='native') hits /jobs/<id>/circuits/native and
-    returns the JSON-decoded body as a string."""
+    """compiled_circuit_text(lang='native') hits /jobs/<id>/circuits/native
+    and returns the JSON-decoded body as a string."""
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
@@ -958,12 +958,12 @@ def test_dry_run_compiled_native(mock_backend, requests_mock):
     )
 
     job = ionq_job.IonQJob(mock_backend, job_id)
-    assert job.compiled_circuit() == native_body
-    assert job.compiled_circuit(lang="native") == native_body
+    assert job.compiled_circuit_text() == native_body
+    assert job.compiled_circuit_text(lang="native") == native_body
 
 
 def test_dry_run_compiled_qasm3(mock_backend, requests_mock):
-    """compiled_circuit(lang='qasm3') returns the OpenQASM 3 string."""
+    """compiled_circuit_text(lang='qasm3') returns the OpenQASM 3 string."""
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
@@ -977,7 +977,7 @@ def test_dry_run_compiled_qasm3(mock_backend, requests_mock):
     )
 
     job = ionq_job.IonQJob(mock_backend, job_id)
-    assert job.compiled_circuit(lang="qasm3") == qasm3
+    assert job.compiled_circuit_text(lang="qasm3") == qasm3
 
 
 def test_compiled_lang_passthrough(mock_backend, requests_mock):
@@ -998,7 +998,7 @@ def test_compiled_lang_passthrough(mock_backend, requests_mock):
         json="some-payload",
     )
     job = ionq_job.IonQJob(mock_backend, job_id)
-    assert job.compiled_circuit(lang="future-lang") == "some-payload"
+    assert job.compiled_circuit_text(lang="future-lang") == "some-payload"
 
 
 def test_compiled_lang_api_error(mock_backend, requests_mock):
@@ -1020,7 +1020,7 @@ def test_compiled_lang_api_error(mock_backend, requests_mock):
     )
     job = ionq_job.IonQJob(mock_backend, job_id)
     with pytest.raises(exceptions.IonQAPIError):
-        job.compiled_circuit(lang="nope")
+        job.compiled_circuit_text(lang="nope")
 
 
 def test_dry_run_property_false(mock_backend, requests_mock):
@@ -1059,7 +1059,7 @@ def test_multi_null_meta_result(mock_backend, requests_mock):
 
 
 # ---------------------------------------------------------------------------
-# compiled_qiskit_circuit (QASM 3 -> QuantumCircuit)
+# compiled_circuit (QASM 3 -> QuantumCircuit)
 # ---------------------------------------------------------------------------
 
 _QASM3_BELL = """OPENQASM 3.0;
@@ -1073,8 +1073,8 @@ c[1] = measure q[1];
 """
 
 
-def test_compiled_qiskit_circuit(mock_backend, requests_mock):
-    """compiled_qiskit_circuit() should fetch QASM 3 and parse it into a
+def test_compiled_circuit(mock_backend, requests_mock):
+    """compiled_circuit() should fetch QASM 3 and parse it into a
     Qiskit QuantumCircuit ready for further inspection."""
     job_id = "dry_run_id"
     requests_mock.get(
@@ -1087,7 +1087,7 @@ def test_compiled_qiskit_circuit(mock_backend, requests_mock):
     )
 
     job = ionq_job.IonQJob(mock_backend, job_id)
-    qc = job.compiled_qiskit_circuit()
+    qc = job.compiled_circuit()
 
     # Round-trip sanity: type is QuantumCircuit, gates are recognisable.
     assert isinstance(qc, QuantumCircuit)
@@ -1100,7 +1100,8 @@ def test_compiled_qiskit_circuit(mock_backend, requests_mock):
 
 def test_compiled_qc_unparseable(mock_backend, requests_mock):
     """If the API returns text the QASM 3 importer cannot parse, the user
-    should get a clear IonQJobError pointing back to compiled_circuit()."""
+    should get a clear IonQJobError pointing back to
+    compiled_circuit_text()."""
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
@@ -1113,4 +1114,4 @@ def test_compiled_qc_unparseable(mock_backend, requests_mock):
 
     job = ionq_job.IonQJob(mock_backend, job_id)
     with pytest.raises(exceptions.IonQJobError, match="QASM 3"):
-        job.compiled_qiskit_circuit()
+        job.compiled_circuit()

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1056,3 +1056,61 @@ def test_multi_null_meta_result(mock_backend, requests_mock):
     assert result.get_counts(0) == {"00": 512, "11": 512}
     # X: max key 1 -> 1 qubit inferred -> 1-char bitstrings.
     assert result.get_counts(1) == {"1": 1024}
+
+
+# ---------------------------------------------------------------------------
+# compiled_qiskit_circuit (QASM 3 -> QuantumCircuit)
+# ---------------------------------------------------------------------------
+
+_QASM3_BELL = """OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q;
+bit[2] c;
+h q[0];
+cx q[0], q[1];
+c[0] = measure q[0];
+c[1] = measure q[1];
+"""
+
+
+def test_compiled_qiskit_circuit(mock_backend, requests_mock):
+    """compiled_qiskit_circuit() should fetch QASM 3 and parse it into a
+    Qiskit QuantumCircuit ready for further inspection."""
+    job_id = "dry_run_id"
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id),
+        json=_dry_run_job_response(job_id),
+    )
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id, "circuits", "qasm3"),
+        json=_QASM3_BELL,
+    )
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    qc = job.compiled_qiskit_circuit()
+
+    # Round-trip sanity: type is QuantumCircuit, gates are recognisable.
+    assert isinstance(qc, QuantumCircuit)
+    assert qc.num_qubits == 2
+    ops = qc.count_ops()
+    assert ops.get("h") == 1
+    assert ops.get("cx") == 1
+    assert ops.get("measure") == 2
+
+
+def test_compiled_qc_unparseable(mock_backend, requests_mock):
+    """If the API returns text the QASM 3 importer cannot parse, the user
+    should get a clear IonQJobError pointing back to compiled_circuit()."""
+    job_id = "dry_run_id"
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id),
+        json=_dry_run_job_response(job_id),
+    )
+    requests_mock.get(
+        mock_backend.client.make_path("jobs", job_id, "circuits", "qasm3"),
+        json="this is not openqasm",
+    )
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    with pytest.raises(exceptions.IonQJobError, match="QASM 3"):
+        job.compiled_qiskit_circuit()

--- a/test/ionq_provider/test_backend_service.py
+++ b/test/ionq_provider/test_backend_service.py
@@ -25,6 +25,8 @@
 # limitations under the License.
 """Test basic provider API methods."""
 
+import pytest
+
 from qiskit_ionq import IonQProvider
 
 
@@ -60,3 +62,35 @@ def test_backend_eq():
     assert sub1 != sub2
     assert also_sub1 != sub2
     assert sub1 != simulator
+
+
+# ---------------------------------------------------------------------------
+# Native-gateset two-qubit instruction selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected_2q",
+    [
+        # ZZ-class
+        ("ionq_qpu.forte-1", "zz"),
+        ("ionq_qpu.forte-enterprise-1", "zz"),
+        ("ionq_qpu.tempo-1", "zz"),
+        # MS-class
+        ("ionq_qpu.aria-1", "ms"),
+        ("ionq_qpu.aria-2", "ms"),
+        # Generic / unrecognised falls back to MS, matching pre-existing behaviour
+        ("ionq_qpu.unknown-1", "ms"),
+    ],
+)
+def test_native_2q_gate(name, expected_2q):
+    """The native-gateset Target should expose ZZ on Forte/Tempo and MS on Aria."""
+    pro = IonQProvider("123456")
+    backend = pro.get_backend(name, gateset="native")
+    instr_names = set(backend.target.operation_names)
+    assert (
+        expected_2q in instr_names
+    ), f"{name}: expected {expected_2q!r} in target ops, got {instr_names}"
+    # And the *other* 2q native gate must NOT be present, to keep the Target unambiguous.
+    other = "ms" if expected_2q == "zz" else "zz"
+    assert other not in instr_names, f"{name}: unexpected {other!r} in target ops"

--- a/test/ionq_provider/test_backend_service.py
+++ b/test/ionq_provider/test_backend_service.py
@@ -88,9 +88,7 @@ def test_native_2q_gate(name, expected_2q):
     pro = IonQProvider("123456")
     backend = pro.get_backend(name, gateset="native")
     instr_names = set(backend.target.operation_names)
-    assert (
-        expected_2q in instr_names
-    ), f"{name}: expected {expected_2q!r} in target ops, got {instr_names}"
+    assert expected_2q in instr_names
     # And the *other* 2q native gate must NOT be present, to keep the Target unambiguous.
     other = "ms" if expected_2q == "zz" else "zz"
-    assert other not in instr_names, f"{name}: unexpected {other!r} in target ops"
+    assert other not in instr_names


### PR DESCRIPTION
Brings the three tempo-branch PRs into `main`, plus the small review polish from the cherry-pick session.

### What's in here

- **#247 — ZZ as native 2q gate for Tempo-class backends.** Adds `"tempo": "zz"` to `NATIVE_2Q_BY_FAMILY` so Tempo systems get `ZZGate` (instead of `MSGate`) on the native target. Parametrized regression test covers Aria → MS, Forte → ZZ, Tempo → ZZ dispatch.

- **#248 — `compilation=` kwarg.** Surface the API's `settings.compilation` block on `backend.run(qc, compilation={...})`. Fields (`service_version`, `opt`, `precision`, `gate_basis`, …) are forwarded verbatim to [the create-job endpoint](https://docs.ionq.com/api-reference/v0.4/jobs/create-job). When both `compilation=` and `job_settings={"compilation": {...}}` are passed, the explicit kwarg wins on overlapping keys; non-overlapping keys from `job_settings` are preserved.

- **#249 + review fixups — `IonQJob.compiled_circuit()` returning a `QuantumCircuit`.** Reshape the compiled-circuit surface so each method has a single return type:
  - `compiled_circuit()` → `QuantumCircuit` (the natural call for Qiskit users)
  - `compiled_circuit_text(lang="native"|"qasm3")` → `str` (raw IonQ JSON / OpenQASM 3)

  Renames the existing `compiled_circuit(lang=...)` from the dry-run/CaaS work to `compiled_circuit_text(lang=...)`. Safe to do now: both methods are still pre-1.0.3 / unreleased (PyPI is at 1.0.2).

Also adds `qiskit[qasm3-import]` to `requirements.txt` for the QASM 3 parsing path used by `compiled_circuit()`.

### Validation

395 tests pass · pylint 10.00/10 · ruff / pre-commit clean.

### Note for reviewers

This branch is a clean, conflict-resolved rebase of the tempo work onto current `main` — the original `tempo` branch had divergent history (it predated the squash-merge of #246 and #252). The four commits below are the actual new work; the `tempo` branch itself can be deleted once this lands.
