### PR TITLE
Tempo support: OpenQASM 3 submission, mid-circuit measurement, shot-wise results, @ionq.arrange readback

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,81 @@ job = backend.run(
 
 Fields are passed through verbatim; refer to the [IonQ API reference](https://docs.ionq.com/api-reference/v0.4/jobs/create-job) for the supported values. When both `compilation=` and `job_settings={"compilation": {...}}` are passed, the explicit `compilation=` kwarg wins on overlapping keys; non-overlapping keys from `job_settings` are preserved.
 
+### Tempo backends (mid-circuit measurement, `verbatim`, shot-wise results)
+
+Tempo-class backends (`ionq_qpu.tempo-1`, `ionq_qpu.tempo-2`, …) speak a new payload schema, `ionq.circuit.v2`, served under the same `/v0.4/jobs` endpoint as the existing backends. The provider routes Tempo submissions automatically based on the backend name; Aria/Forte/simulator paths are unchanged.
+
+The v2 schema natively supports **mid-circuit measurement**, **named classical registers**, and three Tempo-specific settings — `verbatim`, `include_leakage`, and `symmetry_verification`:
+
+```python
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+backend = provider.get_backend("ionq_qpu.tempo-1")
+
+q = QuantumRegister(1, "q")
+mid = ClassicalRegister(1, "mid")
+out = ClassicalRegister(1, "output_all")
+qc = QuantumCircuit(q, mid, out)
+qc.h(0)
+qc.measure(0, mid[0])           # mid-circuit measurement
+qc.x(0)
+qc.measure(0, out[0])
+
+job = backend.run(qc, shots=1000)
+```
+
+Results expose three new endpoints — `/results/shots`, `/results/probabilities`, `/results/histogram` — keyed by classical-register name (the IonQ system always appends a final "measure all qubits" readout under the reserved register name `output_all`):
+
+```python
+result = job.result()
+
+# Backward-compatible default: counts over output_all.
+result.get_counts()                       # {"0": 500, "1": 500}
+
+# Per-register data:
+result.probabilities_by_register()
+# {"mid": {"0": 0.49, "1": 0.51}, "output_all": {"0": 0.50, "1": 0.50}}
+
+# Lazy fetches of the other two endpoints:
+job.shots()      # list of per-shot {register_name: [[bits], ...]}
+job.histogram()  # {register_name: {bitstring: count}}
+```
+
+**Verbatim** mode skips the IonQ compiler — useful for hand-optimised native-gate circuits. Pass `verbatim=True` along with `gateset="native"`; the client rejects QIS gates locally before the wire:
+
+```python
+from qiskit_ionq import GPI2Gate, ZZGate
+
+backend = provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+qc = QuantumCircuit(2, 2)
+qc.append(GPI2Gate(0.25), [0])
+qc.append(ZZGate(0.25), [0, 1])
+qc.measure([0, 1], [0, 1])
+job = backend.run(qc, shots=500, verbatim=True)
+```
+
+**Subspace-leakage** reporting (per-shot leakage flags) is opt-in via `include_leakage=True`; access via `result.get_leakage()`. **Symmetry verification** post-processing is opt-in via `symmetry_verification=True`.
+
+#### Inspecting the compiled circuit (`ARRANGE`)
+
+Under `dry_run=True`, `job.compiled_circuit()` returns the post-compilation circuit as a Qiskit `QuantumCircuit`. The Cypress compiler emits ion-parcel rearrangement directives as `@ionq.arrange` annotations on empty `box { }` statements (the OpenQASM 3.1 spec-blessed shape for position-sensitive vendor metadata); these ride through to the returned `QuantumCircuit` as `IonQArrangeAnnotation` instances on the corresponding `BoxOp`s:
+
+```python
+from qiskit_ionq import IonQArrangeAnnotation
+
+job = backend.run(qc, dry_run=True)
+job.wait_for_final_state()
+compiled = job.compiled_circuit()
+
+for inst in compiled.data:
+    if inst.operation.name == "box":
+        for ann in inst.operation.annotations:
+            if isinstance(ann, IonQArrangeAnnotation):
+                print(f"arrange {ann.from_label} -> {ann.to_label} on {ann.targets}")
+```
+
+`ARRANGE` is compiler-only; it cannot be submitted by external users. `verbatim=True` rejects any unrecognised gate label client-side.
+
 ### Basis gates and transpilation
 
 The IonQ provider provides access to the full IonQ Cloud backend, which includes its own transpilation and compilation pipeline. As such, IonQ provider backends have a broad set of "basis gates" that they will accept — effectively anything the IonQ API will accept. The current supported gates can be found [on our docs site](https://docs.ionq.com/#tag/quantum_programs).

--- a/qiskit_ionq/__init__.py
+++ b/qiskit_ionq/__init__.py
@@ -38,6 +38,12 @@ from .version import __version__
 from .ionq_gates import GPIGate, GPI2Gate, MSGate, ZZGate
 from .constants import ErrorMitigation
 from .ionq_equivalence_library import add_equivalences
+from .ionq_annotations import (
+    IONQ_ARRANGE_NAMESPACE,
+    IonQArrangeAnnotation,
+    IonQArrangeSerializer,
+    ionq_annotation_handlers,
+)
 
 __all__ = [
     "__version__",
@@ -52,5 +58,9 @@ __all__ = [
     "MSGate",
     "ZZGate",
     "ErrorMitigation",
+    "IONQ_ARRANGE_NAMESPACE",
+    "IonQArrangeAnnotation",
+    "IonQArrangeSerializer",
+    "ionq_annotation_handlers",
     "add_equivalences",
 ]

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -158,6 +158,26 @@ def native_2q_gate(value: str | None) -> Literal["ms", "zz"] | None:
     return None
 
 
+# Backend-name fragments that select the ``ionq.circuit.v2`` payload schema
+# instead of the v1 JSON dict. v2 carries an OpenQASM 3 string in ``input``
+# and supports mid-circuit measurement, named classical registers, and the
+# Tempo-class settings (verbatim, include_leakage, symmetry_verification).
+# New v2 backend families should be appended here.
+V2_BACKEND_FAMILIES: tuple[str, ...] = ("tempo",)
+
+
+def is_v2_backend(name: str | None) -> bool:
+    """True when the named backend takes the ``ionq.circuit.v2`` payload.
+
+    Accepts any of the local (``ionq_qpu.tempo-1``), API (``qpu.tempo-1``),
+    or bare (``tempo-1``) name forms.
+    """
+    if not isinstance(name, str):
+        return False
+    lowered = name.lower()
+    return any(fam in lowered for fam in V2_BACKEND_FAMILIES)
+
+
 def qiskit_circ_to_ionq_circ(
     input_circuit: QuantumCircuit,
     gateset: Literal["qis", "native"] = "qis",
@@ -436,6 +456,155 @@ def decompress_metadata_string(
     return json.loads(decompressed)
 
 
+# Native-gate names accepted under ``verbatim=True`` (Cypress external
+# gateset, per the v2 spec). ``barrier`` and ``id`` are stripped by the
+# qasm3 exporter / Cypress respectively and are always permitted.
+_VERBATIM_ALLOWED_GATES: frozenset[str] = frozenset(
+    {"gpi", "gpi2", "ms", "zz", "measure", "barrier", "id"}
+)
+
+
+def _to_qasm3_input(circuit: QuantumCircuit) -> str:
+    """Serialize a Qiskit circuit to an OpenQASM 3 string for v2 submission.
+
+    Uses :func:`qiskit.qasm3.dumps` so IonQ native gates ride through as
+    declared ``gate`` blocks (see :mod:`qiskit_ionq.ionq_gates` for the
+    standard-gate definitions used as the body) and standard QIS gates
+    come from ``stdgates.inc``. Mid-circuit measurement is preserved.
+    """
+    # Imported lazily so the qasm3 exporter is only paid for when v2 is used.
+    from qiskit.qasm3 import dumps as _qasm3_dumps  # pylint: disable=import-outside-toplevel
+
+    return _qasm3_dumps(circuit)
+
+
+def _validate_verbatim_circuit(circuit: QuantumCircuit) -> None:
+    """Reject circuits that use gates outside the verbatim gateset.
+
+    Per the v2 spec, ``verbatim=True`` skips compiler passes and demands
+    native gates only. We catch the common case (a user submitting a QIS
+    circuit with ``verbatim=True``) client-side rather than letting the
+    server reject the whole job after the queue.
+
+    Raises:
+        IonQGateError: if any instruction's name is not in
+            :data:`_VERBATIM_ALLOWED_GATES`.
+    """
+    for inst in circuit.data:
+        name = inst.operation.name
+        if name not in _VERBATIM_ALLOWED_GATES:
+            raise ionq_exceptions.IonQGateError(name, "native")
+
+
+def _qiskit_to_ionq_v2(  # pylint: disable=too-many-positional-arguments,too-many-locals,too-many-branches
+    circuit,
+    backend,
+    backend_name: str,
+    passed_args: dict,
+    extra_query_params: dict,
+    extra_metadata: dict,
+) -> str:
+    """Build the ``ionq.circuit.v2`` payload for Tempo-class backends.
+
+    The v2 schema (defined alongside the MCM output format, served under
+    the existing ``/v0.4/jobs`` endpoint) carries an OpenQASM 3 string in
+    ``input`` and surfaces three new top-level settings:
+    ``verbatim``, ``include_leakage``, and
+    ``error_mitigation.symmetry_verification``.
+
+    Multi-circuit submissions are not supported under v2 (the
+    ``ionq.multi-circuit.v2`` schema is not yet defined); callers passing
+    a list of circuits get a clear :class:`IonQJobError`.
+    """
+    if isinstance(circuit, (list, tuple)):
+        raise ionq_exceptions.IonQJobError(
+            "Multi-circuit submission is not yet supported on Tempo-class "
+            "backends. Submit each circuit as its own job."
+        )
+
+    # Settings block: start from any user-provided job_settings, then layer
+    # the explicit kwargs on top so the kwargs win on overlap (same rule
+    # as the v1 path documents).
+    settings: dict[str, Any] = dict(passed_args.get("job_settings") or {})
+
+    error_mitigation = passed_args.get("error_mitigation") or backend.options.get(
+        "error_mitigation"
+    )
+    if isinstance(error_mitigation, ErrorMitigation):
+        em_block = dict(settings.get("error_mitigation") or {})
+        em_block.update(error_mitigation.value)
+        settings["error_mitigation"] = em_block
+
+    # symmetry_verification rides under settings.error_mitigation alongside
+    # debiasing, matching the v2 spec.
+    symmetry_verification = passed_args.get(
+        "symmetry_verification"
+    ) or backend.options.get("symmetry_verification")
+    if symmetry_verification is not None:
+        em_block = dict(settings.get("error_mitigation") or {})
+        em_block["symmetry_verification"] = bool(symmetry_verification)
+        settings["error_mitigation"] = em_block
+
+    verbatim = passed_args.get("verbatim")
+    if verbatim is None:
+        verbatim = backend.options.get("verbatim")
+    if verbatim:
+        _validate_verbatim_circuit(circuit)
+        settings["verbatim"] = True
+
+    include_leakage = passed_args.get("include_leakage")
+    if include_leakage is None:
+        include_leakage = backend.options.get("include_leakage")
+    if include_leakage is not None:
+        settings["include_leakage"] = bool(include_leakage)
+
+    # Compilation kwarg (existing v1 feature, also accepted on v2).
+    compilation = passed_args.get("compilation")
+    if compilation:
+        existing = dict(settings.get("compilation") or {})
+        existing.update(compilation)
+        settings["compilation"] = existing
+
+    ionq_json: dict[str, Any] = {
+        "type": "ionq.circuit.v2",
+        "backend": backend_name,
+        "shots": passed_args.get("shots"),
+        "name": passed_args.get("name") or circuit.name,
+        "input": _to_qasm3_input(circuit),
+        "metadata": {
+            "shots": str(passed_args.get("shots")),
+            "qiskit_header": compress_to_metadata_string(
+                {
+                    "memory_slots": circuit.num_clbits,
+                    "global_phase": circuit.global_phase,
+                    "n_qubits": circuit.num_qubits,
+                    "name": circuit.name,
+                    "creg_sizes": get_register_sizes_and_labels(circuit.cregs)[0],
+                    "clbit_labels": get_register_sizes_and_labels(circuit.cregs)[1],
+                    "qreg_sizes": get_register_sizes_and_labels(circuit.qregs)[0],
+                    "qubit_labels": get_register_sizes_and_labels(circuit.qregs)[1],
+                    **({"metadata": circuit.metadata} if circuit.metadata else {}),
+                }
+            ),
+            "user_agent": get_user_agent(),
+        },
+    }
+
+    if passed_args.get("session_id") is not None:
+        ionq_json["session_id"] = passed_args["session_id"]
+
+    if settings:
+        ionq_json["settings"] = settings
+
+    if passed_args.get("dry_run"):
+        ionq_json["dry_run"] = True
+
+    ionq_json.update(extra_query_params)
+    ionq_json["metadata"].update(extra_metadata)
+
+    return json.dumps(ionq_json, cls=SafeEncoder)
+
+
 def qiskit_to_ionq(
     circuit,
     backend,
@@ -458,6 +627,24 @@ def qiskit_to_ionq(
     passed_args = passed_args or {}
     extra_query_params = extra_query_params or {}
     extra_metadata = extra_metadata or {}
+
+    # Tempo-class backends speak the ``ionq.circuit.v2`` payload schema, which
+    # carries an OpenQASM 3 string in ``input`` and supports mid-circuit
+    # measurement, named classical registers, and the verbatim /
+    # include_leakage / symmetry_verification settings. Route those before
+    # touching the legacy v1 dict builder.
+    backend_name_for_dispatch = (
+        backend.name[5:] if backend.name.startswith("ionq") else backend.name
+    )
+    if is_v2_backend(backend_name_for_dispatch):
+        return _qiskit_to_ionq_v2(
+            circuit,
+            backend,
+            backend_name_for_dispatch,
+            passed_args,
+            extra_query_params,
+            extra_metadata,
+        )
 
     # build the (multi-)circuit block
     ionq_circs: list[Any] | Any = []

--- a/qiskit_ionq/ionq_annotations.py
+++ b/qiskit_ionq/ionq_annotations.py
@@ -1,0 +1,167 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenQASM 3 annotation support for IonQ-specific compiler directives.
+
+Tempo's compiled-circuit output carries IonQ-specific directives that don't
+exist as quantum gates. The OpenQASM 3 spec recommends representing them as
+namespaced annotations on a host statement (``box`` for position-sensitive
+directives), and Qiskit 2.1+ supports round-tripping annotations on
+``box`` statements via a per-namespace
+:class:`~qiskit.circuit.annotation.OpenQASM3Serializer`.
+
+Currently exposed:
+
+* ``@ionq.arrange`` — ion-parcel rearrangement inserted by the Cypress
+  compiler. Carries the source and destination arrangement labels plus the
+  qubits the operation touches. Only ever appears on the readback path
+  (:meth:`qiskit_ionq.ionq_job.IonQJob.compiled_circuit`); external users
+  cannot include it on submission.
+
+Concrete QASM 3 form::
+
+    @ionq.arrange {"from": "A12S", "to": "A23S", "targets": [0, 1, 2]}
+    box {
+    }
+
+References:
+    OpenQASM 3.1 spec, §Directives (annotations + ``box``):
+      https://openqasm.com/language/directives.html
+    Qiskit 2.1 annotation framework:
+      https://docs.quantum.ibm.com/api/qiskit/circuit_annotation
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from qiskit.circuit.annotation import Annotation, OpenQASM3Serializer
+
+
+IONQ_ARRANGE_NAMESPACE = "ionq.arrange"
+
+
+@dataclass(frozen=True)
+class IonQArrangeAnnotation(Annotation):
+    """An ``@ionq.arrange`` directive parsed from a compiled QASM 3 program.
+
+    Attributes:
+        from_label: Source arrangement identifier (e.g. ``"A12S"``).
+        to_label: Destination arrangement identifier (e.g. ``"A23S"``).
+        targets: Qubit indices the rearrangement involves.
+
+    These annotations ride on empty :class:`~qiskit.circuit.BoxOp` instances
+    in the round-tripped :class:`~qiskit.circuit.QuantumCircuit`; the box
+    body is empty because the underlying operation is metadata, not a
+    quantum computation.
+    """
+
+    from_label: str
+    to_label: str
+    targets: tuple[int, ...]
+
+    # The Annotation base class declares ``namespace`` as a str attribute; we
+    # need a default so the frozen dataclass can be instantiated positionally
+    # without users restating the namespace each time.
+    namespace: str = IONQ_ARRANGE_NAMESPACE
+
+
+class IonQArrangeSerializer(OpenQASM3Serializer):
+    """Serialise / deserialise :class:`IonQArrangeAnnotation` to OpenQASM 3.
+
+    Payload format is a JSON object: ``{"from": ..., "to": ..., "targets": [...]}``.
+    JSON is chosen because (a) it fits OpenQASM 3's "free-form, no newlines"
+    annotation-payload contract, (b) it round-trips faithfully through the
+    OpenQASM 3 lexer, and (c) it stays self-describing when the schema grows
+    (additional arrangement metadata can be added without breaking older
+    consumers).
+    """
+
+    def dump(self, annotation: Annotation) -> str | Literal[NotImplemented]:
+        """Emit ``{"from": <str>, "to": <str>, "targets": [<int>, ...]}``.
+
+        Called by :func:`qiskit.qasm3.dumps` when emitting a circuit that
+        contains an :class:`IonQArrangeAnnotation`. Returns
+        :data:`NotImplemented` for any other annotation namespace so Qiskit
+        can route to the right serializer.
+        """
+        if not isinstance(annotation, IonQArrangeAnnotation):
+            return NotImplemented
+        return json.dumps(
+            {
+                "from": annotation.from_label,
+                "to": annotation.to_label,
+                "targets": list(annotation.targets),
+            },
+            separators=(",", ":"),
+        )
+
+    def load(
+        self, namespace: str, payload: str
+    ) -> Annotation | Literal[NotImplemented]:
+        """Parse a JSON ``@ionq.arrange`` payload into an :class:`IonQArrangeAnnotation`.
+
+        Called by :func:`qiskit.qasm3.loads` (or :func:`qiskit_qasm3_import.parse`)
+        when it encounters an annotation in the ``ionq.arrange`` namespace.
+        Missing or malformed fields raise :class:`ValueError` so a corrupt
+        compiled-circuit response surfaces as a clear parser error rather
+        than a silently-misparsed annotation.
+        """
+        if namespace != IONQ_ARRANGE_NAMESPACE:
+            return NotImplemented
+        data: dict[str, Any] = json.loads(payload)
+        try:
+            return IonQArrangeAnnotation(
+                from_label=str(data["from"]),
+                to_label=str(data["to"]),
+                targets=tuple(int(t) for t in data["targets"]),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Malformed @ionq.arrange annotation payload: {payload!r}. "
+                "Expected JSON object with string 'from', string 'to', and "
+                "list-of-int 'targets'."
+            ) from exc
+
+
+def ionq_annotation_handlers() -> dict[str, OpenQASM3Serializer]:
+    """Standard ``annotation_handlers`` mapping for IonQ QASM 3 round-trips.
+
+    Pass to :func:`qiskit.qasm3.loads` (and :func:`qiskit.qasm3.dumps` when
+    emitting circuits that carry these annotations) so the IonQ-specific
+    namespaces survive parsing rather than being rejected by the importer.
+    """
+    return {IONQ_ARRANGE_NAMESPACE: IonQArrangeSerializer()}
+
+
+__all__ = [
+    "IONQ_ARRANGE_NAMESPACE",
+    "IonQArrangeAnnotation",
+    "IonQArrangeSerializer",
+    "ionq_annotation_handlers",
+]

--- a/qiskit_ionq/ionq_annotations.py
+++ b/qiskit_ionq/ionq_annotations.py
@@ -58,7 +58,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any
 
 from qiskit.circuit.annotation import Annotation, OpenQASM3Serializer
 
@@ -102,13 +102,14 @@ class IonQArrangeSerializer(OpenQASM3Serializer):
     consumers).
     """
 
-    def dump(self, annotation: Annotation) -> str | Literal[NotImplemented]:
+    def dump(self, annotation: Annotation) -> Any:
         """Emit ``{"from": <str>, "to": <str>, "targets": [<int>, ...]}``.
 
         Called by :func:`qiskit.qasm3.dumps` when emitting a circuit that
         contains an :class:`IonQArrangeAnnotation`. Returns
         :data:`NotImplemented` for any other annotation namespace so Qiskit
-        can route to the right serializer.
+        can route to the right serializer; otherwise returns a single-line
+        JSON string.
         """
         if not isinstance(annotation, IonQArrangeAnnotation):
             return NotImplemented
@@ -121,9 +122,7 @@ class IonQArrangeSerializer(OpenQASM3Serializer):
             separators=(",", ":"),
         )
 
-    def load(
-        self, namespace: str, payload: str
-    ) -> Annotation | Literal[NotImplemented]:
+    def load(self, namespace: str, payload: str) -> Any:
         """Parse a JSON ``@ionq.arrange`` payload into an :class:`IonQArrangeAnnotation`.
 
         Called by :func:`qiskit.qasm3.loads` (or :func:`qiskit_qasm3_import.parse`)

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -141,6 +141,10 @@ class IonQBackend(Backend):
             noise_model="ideal",  # simulator-only
             dry_run=False,  # if True, the API compiles but does not execute
             compilation=None,  # forwarded to settings.compilation block
+            # v2 / Tempo settings (ignored on v1 backends).
+            verbatim=False,  # bypass compiler passes; requires native gates
+            include_leakage=None,  # return subspace-leakage flags per shot
+            symmetry_verification=None,  # EM strategy applied in post-processing
         )
 
     @property

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -285,12 +285,22 @@ class IonQJob(JobV1):
         """
         # Imported here rather than at module load so the qasm3 importer is
         # only paid for when this method is actually called.
-        from qiskit.qasm3 import loads as _qasm3_loads, QASM3ImporterError
-        from openqasm3.parser import QASM3ParsingError
+        from qiskit.qasm3 import (  # pylint: disable=import-outside-toplevel
+            loads as _qasm3_loads,
+            QASM3ImporterError,
+        )
+        from openqasm3.parser import (  # pylint: disable=import-outside-toplevel
+            QASM3ParsingError,
+        )
+        from .ionq_annotations import (  # pylint: disable=import-outside-toplevel
+            ionq_annotation_handlers,
+        )
 
         qasm3_text = self.compiled_circuit_text(lang="qasm3")
         try:
-            return _qasm3_loads(qasm3_text)
+            return _qasm3_loads(
+                qasm3_text, annotation_handlers=ionq_annotation_handlers()
+            )
         except (QASM3ImporterError, QASM3ParsingError) as exc:
             raise exceptions.IonQJobError(
                 f"Could not parse compiled QASM 3 for job {self._job_id} into a "

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -45,7 +45,7 @@ from qiskit import QuantumCircuit
 from qiskit.providers import JobV1, jobstatus
 from qiskit.providers.exceptions import JobTimeoutError
 from .ionq_result import IonQResult as Result
-from .helpers import decompress_metadata_string, normalize
+from .helpers import decompress_metadata_string, is_v2_backend, normalize
 
 from . import constants, exceptions
 
@@ -177,6 +177,12 @@ class IonQJob(JobV1):
         self._execution_time = None
         self._dry_run: bool = False
         self._results_url: str | None = None
+        # v2-only: URLs for the new per-format endpoints. Populated alongside
+        # _results_url when the API response carries
+        # ``type == "ionq.circuit.v2"``.
+        self._shots_url: str | None = None
+        self._histogram_url: str | None = None
+        self._is_v2: bool = False
         self._metadata: dict[str, Any] = {}
 
         if passed_args is not None:
@@ -409,9 +415,75 @@ class IonQJob(JobV1):
                 sharpen=sharpen,
                 extra_query_params=extra_query_params,
             )
-            self._result = self._format_result(response)
+            if self._is_v2:
+                self._result = self._format_result_v2(response)
+            else:
+                self._result = self._format_result(response)
 
         return self._result
+
+    def shots(self, extra_query_params: dict | None = None) -> list[dict]:
+        """Fetch shot-wise results from a Tempo-class (v2) job.
+
+        Hits ``GET /v0.4/jobs/{id}/results/shots`` and returns the ``shots``
+        list verbatim: each entry is a dict keyed by classical-register name
+        (as declared in the submitted OpenQASM 3 source), with the value
+        being a list of bit-lists - one snapshot per assignment to that
+        register during the shot. The reserved register ``output_all``
+        always carries the final "measure all qubits" readout the system
+        appends.
+
+        Raises:
+            IonQJobStateError: If the job has not reached a final state.
+            IonQClientError: If the backend is not a v2 (Tempo-class) backend
+                or the API did not publish a shots URL for this job.
+
+        Returns:
+            list[dict]: The raw ``shots`` array. See the MCM output format
+            for the structure.
+        """
+        return self._fetch_v2_endpoint("shots", extra_query_params)
+
+    def histogram(self, extra_query_params: dict | None = None) -> dict:
+        """Fetch the per-register aggregated histogram from a v2 job.
+
+        Hits ``GET /v0.4/jobs/{id}/results/histogram`` and returns the
+        ``histogram`` block verbatim - a dict keyed by register name, each
+        value mapping bitstring -> shot count.
+
+        Raises:
+            IonQJobStateError: If the job has not reached a final state.
+            IonQClientError: If the backend is not a v2 (Tempo-class) backend
+                or the API did not publish a histogram URL for this job.
+
+        Returns:
+            dict: The ``histogram`` block.
+        """
+        return self._fetch_v2_endpoint("histogram", extra_query_params)
+
+    def _fetch_v2_endpoint(self, kind: str, extra_query_params: dict | None) -> Any:
+        """Common gatekeeping + fetch for ``shots`` and ``histogram``."""
+        self.status()
+        if self._status not in jobstatus.JOB_FINAL_STATES:
+            raise exceptions.IonQJobStateError(
+                f"Cannot fetch {kind} until the job reaches a final state. "
+                "Call wait_for_final_state() first."
+            )
+        url = self._shots_url if kind == "shots" else self._histogram_url
+        if not url:
+            raise exceptions.IonQClientError(
+                f"This job has no {kind} URL. The /results/{kind} endpoint "
+                "is only published for Tempo-class (ionq.circuit.v2) jobs."
+            )
+        response = self._client.get_results(
+            results_url=url,
+            extra_query_params=extra_query_params,
+        )
+        # The endpoint nests payload under its kind name, e.g.
+        # {"shots": [...]} or {"histogram": {...}}.
+        if isinstance(response, dict) and kind in response:
+            return response[kind]
+        return response
 
     def status(self, detailed: bool = False) -> jobstatus.JobStatus | dict:
         """Retrieve the status of a job.
@@ -472,6 +544,11 @@ class IonQJob(JobV1):
 
             self._num_qubits = self._first_of(stats, "qubits", default=0)
 
+            # Detect the payload type once; v2 carries per-register results.
+            self._is_v2 = response.get("type") == "ionq.circuit.v2" or is_v2_backend(
+                response.get("backend")
+            )
+
             # Dry-run jobs never produce a results URL; skip extraction so we
             # don't fall through to a None _results_url that would later crash
             # in IonQClient.make_path().
@@ -479,11 +556,15 @@ class IonQJob(JobV1):
                 _results_url = self._first_of(
                     response, "results", "results_url", default={}
                 )
-                self._results_url = (
-                    _results_url
-                    if isinstance(_results_url, str)
-                    else _results_url.get("probabilities", {}).get("url")
-                )
+                if isinstance(_results_url, str):
+                    self._results_url = _results_url
+                else:
+                    self._results_url = _results_url.get("probabilities", {}).get("url")
+                    # v2 also publishes /shots and /histogram alongside the
+                    # probabilities URL. Either may be absent in the v1 case;
+                    # leave them None if so.
+                    self._shots_url = _results_url.get("shots", {}).get("url")
+                    self._histogram_url = _results_url.get("histogram", {}).get("url")
 
             # Classical-bit maps per circuit
             def _meas_map_from_header(header_dict, fallback_nq):
@@ -681,6 +762,109 @@ class IonQJob(JobV1):
                 "job_id": self.job_id(),
                 "backend_name": backend_name,
                 "backend_version": backend_version,
+                "qobj_id": metadata.get("qobj_id"),
+                "success": success,
+                "time_taken": self._execution_time,
+            }
+        )
+
+    def _format_result_v2(self, data):  # pylint: disable=too-many-locals
+        """Translate a v2 (Tempo) probabilities payload into a Qiskit ``Result``.
+
+        The v2 ``/results/probabilities`` endpoint returns a dict keyed by
+        classical-register name, where each value is a dict mapping
+        bitstring -> probability. The reserved register ``output_all``
+        always carries the final "measure all qubits" readout the system
+        appends.
+
+        For Qiskit-compatible ``get_counts()`` behaviour we surface the
+        ``output_all`` distribution as the experiment's primary counts and
+        probabilities (matching the v1 contract). The per-register data
+        rides alongside under ``data["probabilities_by_register"]`` so
+        :meth:`IonQResult.probabilities_by_register` can serve it without a
+        second fetch.
+
+        Args:
+            data (dict): JSON body of ``/results/probabilities``. May be
+                either the raw ``{"probabilities": {...}}`` wrapper or the
+                inner dict, depending on how the client unwraps the response.
+        """
+        backend = self.backend()
+        success = self._status == jobstatus.JobStatus.DONE
+        metadata = self._metadata.get("metadata") or {}
+        qiskit_header = decompress_metadata_string(metadata.get("qiskit_header")) or {}
+        if isinstance(qiskit_header, list):
+            # v2 is single-circuit only; pick the first header if a list slipped in.
+            qiskit_header = qiskit_header[0] if qiskit_header else {}
+        shots = (
+            int(metadata.get("shots", 1024))
+            if str(metadata.get("shots", "1024")).isdigit()
+            else 1024
+        )
+
+        # Unwrap if the payload still has the outer key.
+        per_register = data.get("probabilities", data) if isinstance(data, dict) else {}
+        if not isinstance(per_register, dict):
+            per_register = {}
+
+        # output_all drives the primary counts; bitstrings come back
+        # big-endian / right-most-bit-is-qubit-0 in the v2 spec, matching the
+        # MCM doc examples.
+        output_all = per_register.get("output_all", {}) or {}
+        counts: dict[str, int] = {}
+        probabilities: dict[str, float] = {}
+        for bitstring, prob in output_all.items():
+            cnt = round(float(prob) * shots)
+            if cnt:
+                counts[bitstring] = int(cnt)
+                probabilities[bitstring] = float(prob)
+
+        # Qiskit's Counts class splits the bitstring across the header's
+        # creg_sizes; for get_counts() we present output_all as the single
+        # register, so per-register data does not bleed into the formatted
+        # bitstrings. Per-register access is available via
+        # IonQResult.probabilities_by_register().
+        output_all_width = (
+            max(len(b) for b in output_all)
+            if output_all
+            else qiskit_header.get("memory_slots", 0)
+        )
+        counts_header = dict(qiskit_header or {})
+        counts_header["creg_sizes"] = [["output_all", output_all_width]]
+        counts_header["memory_slots"] = output_all_width
+        counts_header["clbit_labels"] = [
+            ["output_all", i] for i in range(output_all_width)
+        ]
+
+        # Any per-register leakage data the API surfaces top-level under
+        # ``output.error_mitigation.leakage`` when include_leakage=True.
+        leakage = (
+            ((data or {}).get("output") or {})
+            .get("error_mitigation", {})
+            .get("leakage")
+        )
+
+        job_result = [
+            {
+                "data": {
+                    "counts": counts,
+                    "probabilities": probabilities,
+                    "probabilities_by_register": per_register,
+                    "metadata": qiskit_header or {},
+                    **({"leakage": leakage} if leakage is not None else {}),
+                },
+                "shots": shots,
+                "header": counts_header,
+                "success": success,
+            }
+        ]
+
+        return Result.from_dict(
+            {
+                "results": job_result,
+                "job_id": self.job_id(),
+                "backend_name": backend.name,
+                "backend_version": backend.backend_version,
                 "qobj_id": metadata.get("qobj_id"),
                 "success": success,
                 "time_taken": self._execution_time,

--- a/qiskit_ionq/ionq_result.py
+++ b/qiskit_ionq/ionq_result.py
@@ -40,6 +40,12 @@ class IonQResult(Result):
 
     The primary reason this class extends the base Qiskit result object is to
     provide an API for retrieving result probabilities directly.
+
+    Tempo-class (``ionq.circuit.v2``) jobs additionally expose per-register
+    data via :meth:`probabilities_by_register` and per-shot leakage via
+    :meth:`get_leakage`. The standard :meth:`get_counts` /
+    :meth:`get_probabilities` accessors continue to return the ``output_all``
+    distribution for backward compatibility with v1 result-handling code.
     """
 
     def get_probabilities(self, experiment=None):
@@ -92,3 +98,47 @@ class IonQResult(Result):
         if len(dict_list) == 1:
             return dict_list[0]
         return dict_list
+
+    def probabilities_by_register(self, experiment=None) -> dict:
+        """Per-register probability distributions for v2 (Tempo) results.
+
+        Returns a dict keyed by classical-register name (as declared in the
+        submitted OpenQASM 3), where each value is a ``{bitstring: prob}``
+        dict. The reserved register ``output_all`` carries the final
+        "measure all qubits" readout the system appends.
+
+        Args:
+            experiment (int | None): Experiment index. v2 is single-circuit
+                only; this is accepted for API symmetry with the rest of
+                :class:`Result`.
+
+        Raises:
+            IonQJobError: If the experiment has no v2 per-register data
+                (e.g. it was submitted to an Aria/Forte backend).
+
+        Returns:
+            dict[str, dict[str, float]]: ``{register_name: {bitstring: prob}}``.
+        """
+        key = 0 if experiment is None else experiment
+        data = self.data(key)
+        if "probabilities_by_register" not in data:
+            raise exceptions.IonQJobError(
+                f'No per-register probabilities for experiment "{key!r}". This '
+                "endpoint is only populated for Tempo-class (v2) jobs."
+            )
+        return data["probabilities_by_register"]
+
+    def get_leakage(self, experiment=None):
+        """Per-shot subspace-leakage flags for v2 jobs run with ``include_leakage=True``.
+
+        Returns whatever shape the API published under
+        ``output.error_mitigation.leakage``. If the job did not request
+        leakage data, returns ``None``.
+
+        Args:
+            experiment (int | None): Experiment index. v2 is single-circuit
+                only; this is accepted for API symmetry with the rest of
+                :class:`Result`.
+        """
+        key = 0 if experiment is None else experiment
+        return self.data(key).get("leakage")

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,11 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, patch
-VERSION_INFO = ".".join(map(str, (1, 0, 3)))
+# 1.1.0 adds Tempo / ionq.circuit.v2 support: OpenQASM 3 submission,
+# mid-circuit measurement, per-register results (shots / probabilities /
+# histogram endpoints), verbatim mode, subspace-leakage reporting,
+# symmetry verification, and @ionq.arrange annotation round-trip.
+VERSION_INFO = ".".join(map(str, (1, 1, 0)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/test/ionq_tempo/__init__.py
+++ b/test/ionq_tempo/__init__.py
@@ -1,0 +1,27 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Tempo-class (``ionq.circuit.v2``) submission and result paths."""

--- a/test/ionq_tempo/test_arrange_annotation.py
+++ b/test/ionq_tempo/test_arrange_annotation.py
@@ -1,0 +1,187 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``@ionq.arrange`` annotation round-trip tests.
+
+Covers:
+  * Serializer dump/load symmetry for the standalone payload.
+  * Full QASM 3 -> QuantumCircuit ingestion via qiskit.qasm3.loads.
+  * Malformed-payload error path.
+  * IonQJob.compiled_circuit() ingests an arrange annotation from the
+    /circuits/qasm3 endpoint.
+"""
+# pylint: disable=redefined-outer-name
+
+import pytest
+from qiskit.qasm3 import loads as qasm3_loads
+
+from qiskit_ionq import ionq_job
+from qiskit_ionq.helpers import compress_to_metadata_string
+from qiskit_ionq.ionq_annotations import (
+    IONQ_ARRANGE_NAMESPACE,
+    IonQArrangeAnnotation,
+    IonQArrangeSerializer,
+    ionq_annotation_handlers,
+)
+
+
+# ---------------------------------------------------------------------------
+# Serializer-level round trip
+# ---------------------------------------------------------------------------
+
+
+def test_arrange_serializer_dump():
+    """dump() produces a single-line JSON payload with the expected keys."""
+    ann = IonQArrangeAnnotation(from_label="A12S", to_label="A23S", targets=(0, 1, 2))
+    serialized = IonQArrangeSerializer().dump(ann)
+    assert "\n" not in serialized
+    assert '"from":"A12S"' in serialized
+    assert '"to":"A23S"' in serialized
+    assert '"targets":[0,1,2]' in serialized
+
+
+def test_arrange_serializer_load():
+    """load() reconstructs the annotation from a JSON payload."""
+    payload = '{"from":"X","to":"Y","targets":[3,4]}'
+    ann = IonQArrangeSerializer().load(IONQ_ARRANGE_NAMESPACE, payload)
+    assert isinstance(ann, IonQArrangeAnnotation)
+    assert ann.from_label == "X"
+    assert ann.to_label == "Y"
+    assert ann.targets == (3, 4)
+    assert ann.namespace == IONQ_ARRANGE_NAMESPACE
+
+
+def test_load_wrong_ns_skips():
+    """Returning NotImplemented lets Qiskit try a different handler."""
+    out = IonQArrangeSerializer().load("ionq.other", "{}")
+    assert out is NotImplemented
+
+
+def test_dump_wrong_type_skips():
+    """dump() returns NotImplemented for annotations it doesn't own."""
+
+    class DummyAnn:  # pylint: disable=missing-class-docstring,too-few-public-methods
+        namespace = "other.namespace"
+
+    out = IonQArrangeSerializer().dump(DummyAnn())
+    assert out is NotImplemented
+
+
+def test_load_malformed_raises():
+    """A payload missing a required field surfaces as ValueError, not silently parsed wrong."""
+    with pytest.raises(ValueError, match="Malformed"):
+        IonQArrangeSerializer().load(IONQ_ARRANGE_NAMESPACE, '{"from":"X"}')
+
+
+# ---------------------------------------------------------------------------
+# QASM 3 -> QuantumCircuit ingestion
+# ---------------------------------------------------------------------------
+
+
+_ARRANGE_QASM = """OPENQASM 3.1;
+include "stdgates.inc";
+qubit[2] q;
+
+h q[0];
+@ionq.arrange {"from":"A12S","to":"A23S","targets":[0,1]}
+box {
+}
+cx q[0], q[1];
+"""
+
+
+def test_qasm3_loads_attaches_ann():
+    """The annotation handler attaches the IonQArrangeAnnotation to the box op."""
+    qc = qasm3_loads(_ARRANGE_QASM, annotation_handlers=ionq_annotation_handlers())
+    box_insts = [inst for inst in qc.data if inst.operation.name == "box"]
+    assert len(box_insts) == 1
+    annotations = box_insts[0].operation.annotations
+    assert len(annotations) == 1
+    ann = annotations[0]
+    assert isinstance(ann, IonQArrangeAnnotation)
+    assert ann.from_label == "A12S"
+    assert ann.to_label == "A23S"
+    assert ann.targets == (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# IonQJob.compiled_circuit() integration
+# ---------------------------------------------------------------------------
+
+
+def _dry_run_v2_response(job_id: str) -> dict:
+    """A completed dry-run job that produced a v2-style compiled circuit."""
+    return {
+        "id": job_id,
+        "type": "ionq.circuit.v2",
+        "status": "completed",
+        "backend": "qpu.tempo-1",
+        "dry_run": True,
+        "metadata": {
+            "shots": "100",
+            "qiskit_header": compress_to_metadata_string(
+                {
+                    "n_qubits": 2,
+                    "memory_slots": 0,
+                    "name": "dry",
+                    "qreg_sizes": [["q", 2]],
+                    "qubit_labels": [["q", 0], ["q", 1]],
+                    "creg_sizes": [],
+                    "clbit_labels": [],
+                    "global_phase": 0,
+                }
+            ),
+        },
+    }
+
+
+@pytest.fixture
+def arrange_job(provider, requests_mock):
+    """A dry-run Tempo job whose compiled QASM 3 contains @ionq.arrange."""
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="qis")
+    client = backend._create_client()  # pylint: disable=protected-access
+    job_id = "arrange_demo"
+    requests_mock.get(
+        client.make_path("jobs", job_id),
+        json=_dry_run_v2_response(job_id),
+    )
+    requests_mock.get(
+        client.make_path("jobs", job_id, "circuits", "qasm3"),
+        json=_ARRANGE_QASM,
+    )
+    return ionq_job.IonQJob(backend, job_id, client)
+
+
+def test_compiled_circuit_arrange(arrange_job):
+    """compiled_circuit() routes the annotation handler through qasm3.loads."""
+    qc = arrange_job.compiled_circuit()
+    box_insts = [inst for inst in qc.data if inst.operation.name == "box"]
+    assert len(box_insts) == 1
+    ann = box_insts[0].operation.annotations[0]
+    assert isinstance(ann, IonQArrangeAnnotation)
+    assert ann.from_label == "A12S"
+    assert ann.to_label == "A23S"
+    assert ann.targets == (0, 1)

--- a/test/ionq_tempo/test_e2e.py
+++ b/test/ionq_tempo/test_e2e.py
@@ -1,0 +1,264 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end Tempo flow against mocked v2 endpoints.
+
+Mocks the full submission -> poll -> retrieve path through
+``requests_mock`` and asserts that the qiskit-ionq client speaks v2
+correctly on every hop: ``ionq.circuit.v2`` submission with a QASM 3
+``input`` string, then the three new results endpoints, then the
+compiled-circuit readback path with an ``@ionq.arrange`` annotation.
+"""
+# pylint: disable=redefined-outer-name
+
+import json
+
+import pytest
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+
+from qiskit_ionq.helpers import compress_to_metadata_string
+from qiskit_ionq.ionq_annotations import IonQArrangeAnnotation
+
+
+_JOB_ID = "tempo-e2e-id"
+
+
+def _v2_completed_response() -> dict:
+    """Mock /v0.4/jobs/{id} payload that matches the v2 spec."""
+    qiskit_header = compress_to_metadata_string(
+        {
+            "n_qubits": 1,
+            "memory_slots": 2,
+            "name": "mcm_demo",
+            "qreg_sizes": [["q", 1]],
+            "qubit_labels": [["q", 0]],
+            "creg_sizes": [["mid", 1], ["output_all", 1]],
+            "clbit_labels": [["mid", 0], ["output_all", 0]],
+            "global_phase": 0,
+        }
+    )
+    return {
+        "id": _JOB_ID,
+        "type": "ionq.circuit.v2",
+        "status": "completed",
+        "backend": "qpu.tempo-1",
+        "results": {
+            "shots": {"url": f"/v0.4/jobs/{_JOB_ID}/results/shots"},
+            "probabilities": {"url": f"/v0.4/jobs/{_JOB_ID}/results/probabilities"},
+            "histogram": {"url": f"/v0.4/jobs/{_JOB_ID}/results/histogram"},
+        },
+        "metadata": {
+            "shots": "1000",
+            "qiskit_header": qiskit_header,
+        },
+        "execution_duration_ms": 250,
+        "name": "mcm_demo",
+    }
+
+
+_PROBABILITIES = {
+    "probabilities": {
+        "mid": {"0": 0.49, "1": 0.51},
+        "output_all": {"0": 0.50, "1": 0.50},
+    },
+    "output": {
+        "error_mitigation": {
+            "leakage": [[0], [0], [0], [1]],
+        }
+    },
+}
+
+
+_SHOTS = {
+    "shots": [
+        {"mid": [[0]], "output_all": [[0]]},
+        {"mid": [[1]], "output_all": [[1]]},
+        {"mid": [[0]], "output_all": [[1]]},
+    ]
+}
+
+
+_HISTOGRAM = {
+    "histogram": {
+        "mid": {"0": 490, "1": 510},
+        "output_all": {"0": 500, "1": 500},
+    }
+}
+
+
+# A simplified compiled-circuit fixture. The real Cypress MIR->QASM 3
+# transpiler emits ``gate gpi2(phi) q { ... }`` declarations alongside
+# the native-gate invocations; for this test we exercise the annotation
+# handler with stdlib gates so the body parses without IonQ-specific
+# gate definitions.
+_COMPILED_QASM3 = """OPENQASM 3.1;
+include "stdgates.inc";
+qubit[2] q;
+bit[1] mid;
+bit[2] output_all;
+
+h q[0];
+@ionq.arrange {"from":"A12S","to":"A23S","targets":[0,1]}
+box {
+}
+cx q[0], q[1];
+mid[0] = measure q[0];
+output_all[0] = measure q[0];
+output_all[1] = measure q[1];
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mcm_circuit():
+    """Mid-circuit-measurement circuit Tempo is meant to accept."""
+    qr = QuantumRegister(1, "q")
+    mid = ClassicalRegister(1, "mid")
+    out = ClassicalRegister(1, "output_all")
+    qc = QuantumCircuit(qr, mid, out, name="mcm_demo")
+    qc.h(0)
+    qc.measure(0, mid[0])
+    qc.x(0)
+    qc.measure(0, out[0])
+    return qc
+
+
+@pytest.fixture
+def tempo_backend(provider):
+    """Tempo backend with the QIS gateset (the typical Tempo user path)."""
+    return provider.get_backend("ionq_qpu.tempo-1", gateset="qis")
+
+
+@pytest.fixture
+def mocked_v2(tempo_backend, requests_mock):
+    """Wire up the entire v2 submission + result + compiled-circuit path."""
+    client = tempo_backend._create_client()  # pylint: disable=protected-access
+    # POST /jobs returns just the id+status (the API does not echo the payload).
+    requests_mock.post(
+        client.make_path("jobs"),
+        json={"id": _JOB_ID, "status": "submitted"},
+    )
+    requests_mock.get(
+        client.make_path("jobs", _JOB_ID),
+        json=_v2_completed_response(),
+    )
+    requests_mock.get(
+        client.make_path("jobs", _JOB_ID, "results", "probabilities"),
+        json=_PROBABILITIES,
+    )
+    requests_mock.get(
+        client.make_path("jobs", _JOB_ID, "results", "shots"),
+        json=_SHOTS,
+    )
+    requests_mock.get(
+        client.make_path("jobs", _JOB_ID, "results", "histogram"),
+        json=_HISTOGRAM,
+    )
+    requests_mock.get(
+        client.make_path("jobs", _JOB_ID, "circuits", "qasm3"),
+        json=_COMPILED_QASM3,
+    )
+    return requests_mock
+
+
+# ---------------------------------------------------------------------------
+# Submission shape
+# ---------------------------------------------------------------------------
+
+
+def test_submission_is_v2(tempo_backend, mcm_circuit, mocked_v2):
+    """The POST body is ionq.circuit.v2 with an OpenQASM 3 ``input`` string."""
+    tempo_backend.run(mcm_circuit, shots=1000)
+    post_req = mocked_v2.request_history[0]
+    body = json.loads(post_req.text)
+    assert body["type"] == "ionq.circuit.v2"
+    assert body["backend"] == "qpu.tempo-1"
+    assert isinstance(body["input"], str)
+    assert "OPENQASM 3" in body["input"]
+    # Mid-circuit measure survives serialisation.
+    assert body["input"].count("measure q[0]") == 2
+
+
+# ---------------------------------------------------------------------------
+# Result path
+# ---------------------------------------------------------------------------
+
+
+def test_result_get_counts(tempo_backend, mcm_circuit, mocked_v2):  # pylint: disable=unused-argument
+    """get_counts() reflects output_all (the v1-compatible default register)."""
+    job = tempo_backend.run(mcm_circuit, shots=1000)
+    counts = job.result().get_counts()
+    assert counts == {"0": 500, "1": 500}
+
+
+def test_result_per_register(tempo_backend, mcm_circuit, mocked_v2):  # pylint: disable=unused-argument
+    """probabilities_by_register() exposes both 'mid' and 'output_all'."""
+    job = tempo_backend.run(mcm_circuit, shots=1000)
+    per_reg = job.result().probabilities_by_register()
+    assert set(per_reg.keys()) == {"mid", "output_all"}
+    assert per_reg["mid"]["1"] == pytest.approx(0.51)
+
+
+def test_result_leakage(tempo_backend, mcm_circuit, mocked_v2):  # pylint: disable=unused-argument
+    """get_leakage() returns the per-shot leakage bits."""
+    job = tempo_backend.run(mcm_circuit, shots=1000)
+    leakage = job.result().get_leakage()
+    assert leakage == [[0], [0], [0], [1]]
+
+
+def test_shots_endpoint(tempo_backend, mcm_circuit, mocked_v2):  # pylint: disable=unused-argument
+    """job.shots() returns the shot-wise list keyed by register name."""
+    job = tempo_backend.run(mcm_circuit, shots=1000)
+    shots = job.shots()
+    assert [s["mid"] for s in shots] == [[[0]], [[1]], [[0]]]
+
+
+def test_histogram_endpoint(tempo_backend, mcm_circuit, mocked_v2):  # pylint: disable=unused-argument
+    """job.histogram() returns aggregated counts per register."""
+    job = tempo_backend.run(mcm_circuit, shots=1000)
+    hist = job.histogram()
+    assert hist["mid"] == {"0": 490, "1": 510}
+
+
+# ---------------------------------------------------------------------------
+# Compiled circuit + ARRANGE
+# ---------------------------------------------------------------------------
+
+
+def test_compiled_has_arrange(tempo_backend, mcm_circuit, mocked_v2):  # pylint: disable=unused-argument
+    """compiled_circuit() parses the @ionq.arrange annotation into the BoxOp."""
+    job = tempo_backend.run(mcm_circuit, shots=1000)
+    compiled = job.compiled_circuit()
+    box_insts = [inst for inst in compiled.data if inst.operation.name == "box"]
+    assert len(box_insts) == 1
+    ann = box_insts[0].operation.annotations[0]
+    assert isinstance(ann, IonQArrangeAnnotation)
+    assert ann.from_label == "A12S"
+    assert ann.targets == (0, 1)

--- a/test/ionq_tempo/test_tempo_backend.py
+++ b/test/ionq_tempo/test_tempo_backend.py
@@ -1,0 +1,152 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-side tests for Tempo: name resolution, native target, verbatim gate set."""
+
+import pytest
+from qiskit import QuantumCircuit
+
+from qiskit_ionq import GPI2Gate, GPIGate, MSGate, ZZGate
+from qiskit_ionq.exceptions import IonQGateError
+from qiskit_ionq.helpers import qiskit_to_ionq
+
+
+# ---------------------------------------------------------------------------
+# Provider name resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name", ["ionq_qpu.tempo-1", "qpu.tempo-1", "ionq_qpu.tempo-2"]
+)
+def test_tempo_backend_resolves(provider, name):
+    """Caller can address tempo-N by either the local or API name form."""
+    backend = provider.get_backend(name, gateset="native")
+    assert "tempo" in backend.name.lower()
+    # API form drops the local `ionq_qpu` prefix.
+    assert backend._api_backend_name.startswith("qpu.tempo")  # pylint: disable=protected-access
+
+
+def test_native_target_uses_zz(provider):
+    """The native target for a tempo backend exposes ZZ rather than MS."""
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+    ops = set(backend.target.operation_names)
+    assert "zz" in ops
+    assert "ms" not in ops
+
+
+def test_tempo_qis_target_unchanged(provider):
+    """The QIS-gateset target is the same superset on tempo as on aria/forte."""
+    tempo = provider.get_backend("ionq_qpu.tempo-1", gateset="qis")
+    forte = provider.get_backend("ionq_qpu.forte-1", gateset="qis")
+    assert set(tempo.target.operation_names) == set(forte.target.operation_names)
+
+
+# ---------------------------------------------------------------------------
+# Verbatim gate-set validation
+# ---------------------------------------------------------------------------
+
+
+def _native_qc():
+    """Native-gate circuit valid for verbatim submission."""
+    qc = QuantumCircuit(2, 2)
+    qc.append(GPI2Gate(0.5), [0])
+    qc.append(GPIGate(0.25), [1])
+    qc.append(ZZGate(0.25), [0, 1])
+    qc.measure([0, 1], [0, 1])
+    return qc
+
+
+def test_verbatim_accepts_zz_native(provider):
+    """A circuit using gpi/gpi2/zz/measure passes verbatim validation."""
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+    # Should not raise.
+    qiskit_to_ionq(
+        _native_qc(), backend, passed_args={"shots": 100, "verbatim": True}
+    )
+
+
+def test_verbatim_accepts_ms_native(provider):
+    """MS is in the verbatim gate set too (Aria-class native), and is accepted."""
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+    qc = QuantumCircuit(2, 2)
+    qc.append(GPI2Gate(0.0), [0])
+    qc.append(MSGate(0.0, 0.0, 0.25), [0, 1])
+    qc.measure([0, 1], [0, 1])
+    qiskit_to_ionq(qc, backend, passed_args={"shots": 100, "verbatim": True})
+
+
+def test_verbatim_rejects_h_gate(provider):
+    """Common QIS gates (h, cx, rx, etc.) cannot ride through verbatim."""
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    with pytest.raises(IonQGateError) as exc:
+        qiskit_to_ionq(qc, backend, passed_args={"shots": 100, "verbatim": True})
+    assert exc.value.gate_name == "h"
+
+
+def test_verbatim_rejects_cx_gate(provider):
+    """CX is not native on IonQ — verbatim must reject it before the wire."""
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+    qc = QuantumCircuit(2, 2)
+    qc.cx(0, 1)
+    qc.measure([0, 1], [0, 1])
+    with pytest.raises(IonQGateError) as exc:
+        qiskit_to_ionq(qc, backend, passed_args={"shots": 100, "verbatim": True})
+    assert exc.value.gate_name == "cx"
+
+
+def test_verbatim_rejects_arrange(provider):
+    """ARRANGE is compiler-only; users cannot submit it (per the v2 RFC).
+
+    A custom-named operation surfaces here as ``IonQGateError`` because it is
+    not in the verbatim allow-list. This is the client-side guard; the server
+    would also reject it but failing fast saves a round-trip + queue wait.
+    """
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+    qc = QuantumCircuit(2, 2)
+    qc.barrier()  # placeholder; barrier is allowed
+    # Build a fake "arrange" instruction with an unrecognised name.
+    qc.unitary(
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+        [0, 1],
+        label="arrange",
+    )
+    qc.measure([0, 1], [0, 1])
+    with pytest.raises(IonQGateError):
+        qiskit_to_ionq(qc, backend, passed_args={"shots": 100, "verbatim": True})
+
+
+def test_no_verbatim_no_validation(provider):
+    """Without verbatim=True, QIS gates ride through unmolested for compiler synthesis."""
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="qis")
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    # Should not raise even though h() is not in the verbatim allow-list.
+    qiskit_to_ionq(qc, backend, passed_args={"shots": 100})

--- a/test/ionq_tempo/test_v2_results.py
+++ b/test/ionq_tempo/test_v2_results.py
@@ -170,7 +170,7 @@ def test_v2_probs_by_register(tempo_job):
     assert per_reg["output_all"] == {"0": 0.50, "1": 0.50}
 
 
-def test_v1_probs_by_register_raises(formatted_result):
+def test_v1_probs_by_reg_raises(formatted_result):
     """V1 results don't have per-register data; the accessor raises clearly."""
     with pytest.raises(IonQJobError, match="per-register"):
         formatted_result.probabilities_by_register()

--- a/test/ionq_tempo/test_v2_results.py
+++ b/test/ionq_tempo/test_v2_results.py
@@ -1,0 +1,258 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Result-side tests for the ``ionq.circuit.v2`` (Tempo) payload.
+
+Covers:
+  * ``IonQJob`` detects the v2 ``type`` and stores per-format result URLs.
+  * ``IonQResult.get_counts()`` aggregates ``output_all`` for backward compat.
+  * ``IonQResult.probabilities_by_register()`` surfaces per-register data.
+  * ``IonQJob.shots()`` / ``IonQJob.histogram()`` lazy-fetch the new endpoints.
+  * ``IonQResult.get_leakage()`` surfaces subspace-leakage flags.
+"""
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from qiskit_ionq import ionq_job
+from qiskit_ionq.exceptions import IonQClientError, IonQJobError
+from qiskit_ionq.helpers import compress_to_metadata_string
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a v2 job response and the three results endpoints.
+# ---------------------------------------------------------------------------
+
+
+_V2_JOB_ID = "v2_job_id"
+
+
+def _v2_qiskit_header(name: str = "tempo_demo") -> str:
+    return compress_to_metadata_string(
+        {
+            "n_qubits": 1,
+            "memory_slots": 2,
+            "name": name,
+            "qreg_sizes": [["q", 1]],
+            "qubit_labels": [["q", 0]],
+            "creg_sizes": [["mid", 1], ["output_all", 1]],
+            "clbit_labels": [["mid", 0], ["output_all", 0]],
+            "global_phase": 0,
+        }
+    )
+
+
+def _v2_job_response(job_id: str = _V2_JOB_ID) -> dict:
+    """Job-record payload as the API returns for a completed v2 job."""
+    return {
+        "id": job_id,
+        "type": "ionq.circuit.v2",
+        "status": "completed",
+        "backend": "qpu.tempo-1",
+        "results": {
+            "shots": {"url": f"/v0.4/jobs/{job_id}/results/shots"},
+            "probabilities": {"url": f"/v0.4/jobs/{job_id}/results/probabilities"},
+            "histogram": {"url": f"/v0.4/jobs/{job_id}/results/histogram"},
+        },
+        "metadata": {
+            "shots": "1000",
+            "qiskit_header": _v2_qiskit_header(),
+        },
+        "execution_duration_ms": 250,
+        "name": "tempo_demo",
+    }
+
+
+_V2_PROBABILITIES = {
+    "probabilities": {
+        "mid": {"0": 0.49, "1": 0.51},
+        "output_all": {"0": 0.50, "1": 0.50},
+    }
+}
+
+
+_V2_SHOTS = {
+    "shots": [
+        {"mid": [[0]], "output_all": [[0]]},
+        {"mid": [[1]], "output_all": [[1]]},
+        {"mid": [[0]], "output_all": [[1]]},
+    ]
+}
+
+
+_V2_HISTOGRAM = {
+    "histogram": {
+        "mid": {"0": 490, "1": 510},
+        "output_all": {"0": 500, "1": 500},
+    }
+}
+
+
+@pytest.fixture
+def tempo_job(provider, requests_mock):
+    """An IonQJob attached to a completed v2 job, with all endpoints mocked."""
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="qis")
+    client = backend._create_client()  # pylint: disable=protected-access
+    requests_mock.get(
+        client.make_path("jobs", _V2_JOB_ID),
+        json=_v2_job_response(_V2_JOB_ID),
+    )
+    requests_mock.get(
+        client.make_path("jobs", _V2_JOB_ID, "results", "probabilities"),
+        json=_V2_PROBABILITIES,
+    )
+    requests_mock.get(
+        client.make_path("jobs", _V2_JOB_ID, "results", "shots"),
+        json=_V2_SHOTS,
+    )
+    requests_mock.get(
+        client.make_path("jobs", _V2_JOB_ID, "results", "histogram"),
+        json=_V2_HISTOGRAM,
+    )
+    return ionq_job.IonQJob(backend, _V2_JOB_ID, client)
+
+
+# ---------------------------------------------------------------------------
+# v2 detection
+# ---------------------------------------------------------------------------
+
+
+def test_v2_job_detection(tempo_job):
+    """The job recognises ``type: ionq.circuit.v2`` and stores all three URLs."""
+    assert tempo_job._is_v2 is True  # pylint: disable=protected-access
+    assert tempo_job._results_url.endswith("/results/probabilities")  # pylint: disable=protected-access
+    assert tempo_job._shots_url.endswith("/results/shots")  # pylint: disable=protected-access
+    assert tempo_job._histogram_url.endswith("/results/histogram")  # pylint: disable=protected-access
+
+
+# ---------------------------------------------------------------------------
+# Probability decoding
+# ---------------------------------------------------------------------------
+
+
+def test_v2_counts_from_output_all(tempo_job):
+    """get_counts() reflects the output_all register (the v1-compatible default)."""
+    result = tempo_job.result()
+    counts = result.get_counts()
+    # output_all = {"0": 0.5, "1": 0.5}, shots=1000 -> 500 of each
+    assert counts == {"0": 500, "1": 500}
+
+
+def test_v2_probs_by_register(tempo_job):
+    """probabilities_by_register() exposes each declared classical register."""
+    result = tempo_job.result()
+    per_reg = result.probabilities_by_register()
+    assert set(per_reg.keys()) == {"mid", "output_all"}
+    assert per_reg["mid"] == {"0": 0.49, "1": 0.51}
+    assert per_reg["output_all"] == {"0": 0.50, "1": 0.50}
+
+
+def test_v1_probs_by_register_raises(formatted_result):
+    """V1 results don't have per-register data; the accessor raises clearly."""
+    with pytest.raises(IonQJobError, match="per-register"):
+        formatted_result.probabilities_by_register()
+
+
+# ---------------------------------------------------------------------------
+# Lazy /shots and /histogram fetches
+# ---------------------------------------------------------------------------
+
+
+def test_v2_shots_endpoint(tempo_job):
+    """job.shots() round-trips the shot list unmodified."""
+    shots = tempo_job.shots()
+    assert len(shots) == 3
+    assert shots[0] == {"mid": [[0]], "output_all": [[0]]}
+    assert shots[2] == {"mid": [[0]], "output_all": [[1]]}
+
+
+def test_v2_histogram_endpoint(tempo_job):
+    """job.histogram() returns the per-register count map."""
+    hist = tempo_job.histogram()
+    assert hist["mid"] == {"0": 490, "1": 510}
+    assert hist["output_all"] == {"0": 500, "1": 500}
+
+
+def test_v1_shots_unavailable(provider, requests_mock):
+    """Non-v2 backends have no shots URL; the accessor raises a clear error."""
+    backend = provider.get_backend("ionq_qpu.aria-1")
+    client = backend._create_client()  # pylint: disable=protected-access
+    job_id = "v1_job"
+    requests_mock.get(
+        client.make_path("jobs", job_id),
+        json={
+            "id": job_id,
+            "type": "ionq.circuit.v1",
+            "status": "completed",
+            "backend": "qpu.aria-1",
+            "results": {
+                "probabilities": {"url": f"/v0.4/jobs/{job_id}/results/probabilities"}
+            },
+            "metadata": {"shots": "1000", "qiskit_header": _v2_qiskit_header()},
+            "execution_duration_ms": 100,
+        },
+    )
+    job = ionq_job.IonQJob(backend, job_id, client)
+    with pytest.raises(IonQClientError, match="Tempo-class"):
+        job.shots()
+    with pytest.raises(IonQClientError, match="Tempo-class"):
+        job.histogram()
+
+
+# ---------------------------------------------------------------------------
+# Leakage
+# ---------------------------------------------------------------------------
+
+
+def test_v2_get_leakage_absent(tempo_job):
+    """When include_leakage was not requested, get_leakage() returns None."""
+    result = tempo_job.result()
+    assert result.get_leakage() is None
+
+
+def test_v2_get_leakage_present(provider, requests_mock):
+    """include_leakage=true: leakage bits ride under output.error_mitigation."""
+    backend = provider.get_backend("ionq_qpu.tempo-1", gateset="qis")
+    client = backend._create_client()  # pylint: disable=protected-access
+    job_id = "v2_leakage_job"
+    requests_mock.get(
+        client.make_path("jobs", job_id),
+        json=_v2_job_response(job_id),
+    )
+    requests_mock.get(
+        client.make_path("jobs", job_id, "results", "probabilities"),
+        json={
+            "probabilities": {"output_all": {"0": 1.0}},
+            "output": {
+                "error_mitigation": {
+                    "leakage": [[0, 0], [0, 1], [0, 0]],
+                }
+            },
+        },
+    )
+    job = ionq_job.IonQJob(backend, job_id, client)
+    leakage = job.result().get_leakage()
+    assert leakage == [[0, 0], [0, 1], [0, 0]]

--- a/test/ionq_tempo/test_v2_submission.py
+++ b/test/ionq_tempo/test_v2_submission.py
@@ -1,0 +1,268 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``qiskit_to_ionq`` -> ``ionq.circuit.v2`` payload tests.
+
+The v2 schema is what Tempo-class backends consume:
+``{"type": "ionq.circuit.v2", "input": "<openqasm 3 string>", ...}``.
+These tests pin the wire shape and the dispatcher in
+:func:`qiskit_ionq.helpers.qiskit_to_ionq`.
+"""
+# pylint: disable=redefined-outer-name
+
+import json
+
+import pytest
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+
+from qiskit_ionq import GPI2Gate, ZZGate
+from qiskit_ionq.exceptions import IonQGateError, IonQJobError
+from qiskit_ionq.helpers import (
+    decompress_metadata_string,
+    is_v2_backend,
+    qiskit_to_ionq,
+)
+
+
+# ---------------------------------------------------------------------------
+# Backend-family dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("ionq_qpu.tempo-1", True),
+        ("qpu.tempo-1", True),
+        ("tempo", True),
+        ("ionq_qpu.tempo-2", True),
+        ("ionq_qpu.aria-1", False),
+        ("ionq_qpu.forte-1", False),
+        ("ionq_qpu.forte-enterprise-1", False),
+        ("ionq_simulator", False),
+        ("simulator", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_v2_backend(name, expected):
+    """The v2-payload dispatcher matches any tempo-flavoured name and only those."""
+    assert is_v2_backend(name) is expected
+
+
+# ---------------------------------------------------------------------------
+# Payload shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tempo_backend(provider):
+    """Native-gateset Tempo backend (the typical user path for v2)."""
+    return provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+
+
+@pytest.fixture
+def tempo_qis_backend(provider):
+    """QIS-gateset Tempo backend (server-side compiler will resynthesize)."""
+    return provider.get_backend("ionq_qpu.tempo-1", gateset="qis")
+
+
+def test_v2_type_and_backend(tempo_qis_backend):
+    """Tempo submission emits ``type=ionq.circuit.v2`` and the stripped backend name."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    payload = json.loads(
+        qiskit_to_ionq(qc, tempo_qis_backend, passed_args={"shots": 50})
+    )
+    assert payload["type"] == "ionq.circuit.v2"
+    assert payload["backend"] == "qpu.tempo-1"
+    assert payload["shots"] == 50
+
+
+def test_v2_input_is_qasm3_string(tempo_qis_backend):
+    """``input`` carries an OpenQASM 3 source string (not the v1 dict)."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    payload = json.loads(
+        qiskit_to_ionq(qc, tempo_qis_backend, passed_args={"shots": 50})
+    )
+    assert isinstance(payload["input"], str)
+    assert payload["input"].startswith("OPENQASM 3")
+    assert "h q[0]" in payload["input"]
+    assert "measure q[0]" in payload["input"]
+
+
+def test_v2_preserves_mid_measure(tempo_qis_backend):
+    """Mid-circuit measure must survive serialization (no exception raised, kept in QASM)."""
+    qr = QuantumRegister(1, "q")
+    mid = ClassicalRegister(1, "mid")
+    out = ClassicalRegister(1, "out")
+    qc = QuantumCircuit(qr, mid, out)
+    qc.h(0)
+    qc.measure(0, mid[0])
+    qc.x(0)
+    qc.measure(0, out[0])
+
+    payload = json.loads(
+        qiskit_to_ionq(qc, tempo_qis_backend, passed_args={"shots": 50})
+    )
+    qasm = payload["input"]
+    # Both measurements present, ordered, and bound to their named registers.
+    assert qasm.count("measure q[0]") == 2
+    assert "mid[0] = measure q[0]" in qasm
+    assert "out[0] = measure q[0]" in qasm
+
+
+def test_v2_named_registers(tempo_qis_backend):
+    """Classical-register names declared by the user appear verbatim in the QASM."""
+    qr = QuantumRegister(2, "q")
+    rega = ClassicalRegister(1, "alpha")
+    regb = ClassicalRegister(2, "beta")
+    qc = QuantumCircuit(qr, rega, regb)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure(0, rega[0])
+    qc.measure([0, 1], [regb[0], regb[1]])
+
+    payload = json.loads(
+        qiskit_to_ionq(qc, tempo_qis_backend, passed_args={"shots": 100})
+    )
+    qasm = payload["input"]
+    assert "bit[1] alpha" in qasm
+    assert "bit[2] beta" in qasm
+
+
+def test_v2_metadata_round_trip(tempo_qis_backend):
+    """The compressed qiskit_header survives so result decoding can reconstruct registers."""
+    qr = QuantumRegister(1, "q")
+    cr = ClassicalRegister(1, "c")
+    qc = QuantumCircuit(qr, cr, name="probe")
+    qc.h(0)
+    qc.measure(0, cr[0])
+
+    payload = json.loads(
+        qiskit_to_ionq(qc, tempo_qis_backend, passed_args={"shots": 100})
+    )
+    header = decompress_metadata_string(payload["metadata"]["qiskit_header"])
+    assert header["name"] == "probe"
+    assert header["n_qubits"] == 1
+    assert header["memory_slots"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Settings routing (verbatim, include_leakage, symmetry_verification)
+# ---------------------------------------------------------------------------
+
+
+def test_v2_verbatim_native_ok(tempo_backend):
+    """A circuit containing only native gates + measure may submit with verbatim=True."""
+    qc = QuantumCircuit(2, 2)
+    qc.append(GPI2Gate(0.25), [0])
+    qc.append(ZZGate(0.25), [0, 1])
+    qc.measure([0, 1], [0, 1])
+
+    payload = json.loads(
+        qiskit_to_ionq(qc, tempo_backend, passed_args={"shots": 100, "verbatim": True})
+    )
+    assert payload["settings"]["verbatim"] is True
+
+
+def test_v2_verbatim_qis_rejects(tempo_backend):
+    """verbatim=True with a QIS gate (e.g. h) should raise IonQGateError client-side."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    with pytest.raises(IonQGateError) as exc:
+        qiskit_to_ionq(qc, tempo_backend, passed_args={"shots": 100, "verbatim": True})
+    assert exc.value.gate_name == "h"
+
+
+def test_v2_include_leakage_flag(tempo_qis_backend):
+    """include_leakage=True ends up at settings.include_leakage."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    payload = json.loads(
+        qiskit_to_ionq(
+            qc, tempo_qis_backend, passed_args={"shots": 50, "include_leakage": True}
+        )
+    )
+    assert payload["settings"]["include_leakage"] is True
+
+
+def test_v2_symmetry_under_em(tempo_qis_backend):
+    """symmetry_verification rides inside settings.error_mitigation."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    payload = json.loads(
+        qiskit_to_ionq(
+            qc,
+            tempo_qis_backend,
+            passed_args={"shots": 50, "symmetry_verification": True},
+        )
+    )
+    em_block = payload["settings"]["error_mitigation"]
+    assert em_block["symmetry_verification"] is True
+
+
+def test_v2_no_settings_default(tempo_qis_backend):
+    """A plain submission should not emit a ``settings`` block at all."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    payload = json.loads(
+        qiskit_to_ionq(qc, tempo_qis_backend, passed_args={"shots": 50})
+    )
+    assert "settings" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Constraints / negative cases
+# ---------------------------------------------------------------------------
+
+
+def test_v2_rejects_multi_circuit(tempo_qis_backend):
+    """The ``ionq.multi-circuit.v2`` schema is not yet defined; we error early."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    with pytest.raises(IonQJobError, match="Multi-circuit"):
+        qiskit_to_ionq([qc, qc], tempo_qis_backend, passed_args={"shots": 50})
+
+
+def test_v1_path_unchanged_for_aria(provider):
+    """Sanity guard: Aria submissions still emit the v1 dict, not a QASM string."""
+    backend = provider.get_backend("ionq_qpu.aria-1")
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    payload = json.loads(qiskit_to_ionq(qc, backend, passed_args={"shots": 50}))
+    assert payload["type"] == "ionq.circuit.v1"
+    assert isinstance(payload["input"], dict)
+    assert payload["input"]["gateset"] == "qis"


### PR DESCRIPTION
Stacks on #253. Adds the qiskit-ionq surface needed to run circuits on Tempo-class backends.

Tempo backends (`ionq_qpu.tempo-*`) speak `ionq.circuit.v2` under the same `/v0.4/jobs` endpoint. Routing is automatic by backend name; Aria, Forte, Forte-Enterprise, and the simulator are byte-for-byte unchanged.

## What's new

- **Submission**: `"input"` is an OpenQASM 3 string via `qiskit.qasm3.dumps`. Mid-circuit measurement preserved. New `verbatim`, `include_leakage`, `symmetry_verification` kwargs. `verbatim=True` validates against `{gpi, gpi2, ms, zz, measure, barrier, id}` client-side. Multi-circuit on Tempo raises (`ionq.multi-circuit.v2` not yet specified).
- **Results**: Three endpoints keyed by classical-register name — `/results/probabilities` (default), `/results/shots` (`job.shots()`), `/results/histogram` (`job.histogram()`). System always appends an `output_all` register. `result.get_counts()` stays v1-compatible (aggregates `output_all`); new `result.probabilities_by_register()` and `result.get_leakage()`.
- **`@ionq.arrange` readback**: New `qiskit_ionq.ionq_annotations` module surfaces ion-rearrangement directives as `IonQArrangeAnnotation` on `BoxOp`s in the `QuantumCircuit` returned by `IonQJob.compiled_circuit()`. ARRANGE is compiler-only; users can't submit it.
- **Version**: bumps to `1.1.0`.

## Commits

1. Submit Tempo jobs as `ionq.circuit.v2` with OpenQASM 3 input
2. Decode v2 shot-wise, probabilities, and histogram results
3. Read `@ionq.arrange` annotations on `compiled_circuit()`
4. Register Tempo backends and validate verbatim circuits
5. Tempo end-to-end tests with mocked v2 responses
6. Document Tempo usage and bump to 1.1.0

## Validation

452 tests pass (was 359 on `tempo-pr`); 93 new under `test/ionq_tempo/`. pylint 10.00/10. ruff / ruff-format / mypy clean.

## Defaults to confirm before merge

If any of these flip, the relevant commit needs a small revision:

1. `"input"` is a literal OpenQASM 3 string at `POST /v0.4/jobs` for v2.
2. `output_all` is always present in results (no opt-out under `verbatim=true`).
3. `@ionq.arrange box {}` is the QASM 3 form Cypress emits for ion rearrangement.
