### PR TITLE
fix: set dry_run flag at job construction time

### DIFF
--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -213,6 +213,7 @@ class IonQJob(JobV1):
             self.extra_query_params = passed_args.pop("extra_query_params", {})
             self.extra_metadata = passed_args.pop("extra_metadata", {})
             self.memory = passed_args.pop("memory", False)
+            self._dry_run = bool(passed_args.get("dry_run", False))
             self._passed_args = passed_args
         else:
             self.extra_query_params = {}

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1146,6 +1146,23 @@ def _dry_run_job_response(job_id, target="qpu.forte-1"):
     }
 
 
+def test_dry_run_set_before_poll(mock_backend):
+    """`dry_run=True` must be reflected on the job immediately, not only after
+    the first status() poll. The v0.4 ``JobCreationResponse`` (POST /jobs 201)
+    only carries ``{id, status, session_id}`` and omits ``dry_run``, so we
+    must mirror the kwarg into ``self._dry_run`` at construction."""
+    job = ionq_job.IonQJob(
+        mock_backend,
+        None,
+        circuit=QuantumCircuit(1, 1),
+        passed_args={"dry_run": True, "shots": 64},
+    )
+    assert job.dry_run is True
+    # ...and the flag must remain in _passed_args so the wire payload still
+    # includes it (helpers.qiskit_to_ionq reads it via .get()).
+    assert job._passed_args.get("dry_run") is True
+
+
 def test_dry_run_no_results_urls(mock_backend, requests_mock):
     """Dry-run jobs should reach DONE without a results URL crash."""
     job_id = "dry_run_id"


### PR DESCRIPTION
## Problem

The v0.4 `POST /jobs` 201 response (`JobCreationResponse` in the [OpenAPI spec](https://github.com/ionq/ionq-core/blob/main/openapi.json)) is intentionally minimal:

```json
{ "id": "...", "status": "submitted", "session_id": null }
```

It does **not** echo back the `dry_run` boolean. `IonQJob.__init__` initialized `self._dry_run = False` unconditionally and only refreshed it from `GetCircuitJobResponse` on the first `status()` poll. So:

```python
job = backend.run(qc, dry_run=True)
if job.dry_run:           # ← False until the next status() call
    print(job.compiled_circuit())
```

returned the wrong value. The flag was always sent on the wire (`helpers.qiskit_to_ionq` reads it from `_passed_args` during payload serialization), only the local mirror was stale.

## Fix

Mirror the kwarg into `self._dry_run` at construction, matching the existing `memory=` path one line above. Uses `.get()` (not `.pop()`) so the wire serializer still picks it up from `_passed_args`.

```diff
         self.memory = passed_args.pop("memory", False)
+        self._dry_run = bool(passed_args.get("dry_run", False))
         self._passed_args = passed_args
```

## Test

Added `test_dry_run_set_before_poll` next to the existing dry-run tests. It constructs an `IonQJob` with `passed_args={'dry_run': True, ...}` and asserts both that `job.dry_run is True` immediately and that `_passed_args["dry_run"]` survives for the wire serializer.

Verified the test fails on `main` (asserts `False is True`) and passes with the fix. Full suite: 393 passed.

## How I found it

End-to-end live verification of features added since v1.0.2 against the IonQ simulator. The bug only surfaces in real usage because the existing unit tests construct the job from a retrieved job ID, which always polls via GET first (and the GET response *does* carry `dry_run`).