### PR TITLE
Add a Qiskit core workflow demo for IonQ users

### DIFF
--- a/docs/guides/qiskit_core.rst
+++ b/docs/guides/qiskit_core.rst
@@ -1,0 +1,63 @@
+=====================
+Qiskit core workflows
+=====================
+
+The IonQ provider can be used with Qiskit's core circuit, transpiler, and
+``quantum_info`` tools before a job is submitted to IonQ Cloud. This is useful
+when you want to validate a circuit locally, inspect the operations that Qiskit
+will send to an IonQ backend, or request an IonQ compilation-only dry run.
+
+The repository includes a runnable script at
+``example/qiskit_core_workflow.py``. By default it does not submit to IonQ Cloud:
+
+.. code-block:: bash
+
+   python example/qiskit_core_workflow.py
+
+The script demonstrates three steps:
+
+* build an unmeasured GHZ circuit with :class:`qiskit.QuantumCircuit`;
+* use :class:`qiskit.quantum_info.Statevector` and
+  :class:`qiskit.quantum_info.SparsePauliOp` to compute a local ``<ZZI...>``
+  expectation value;
+* add measurements and call :func:`qiskit.transpile` against an IonQ backend
+  target.
+
+The core workflow is:
+
+.. code-block:: python
+
+   from qiskit import QuantumCircuit, transpile
+   from qiskit.quantum_info import SparsePauliOp, Statevector
+   from qiskit_ionq import IonQProvider
+
+   provider = IonQProvider()
+   backend = provider.get_backend("ionq_simulator")
+
+   state_prep = QuantumCircuit(3)
+   state_prep.h(0)
+   state_prep.cx(0, 1)
+   state_prep.cx(0, 2)
+
+   observable = SparsePauliOp.from_list([("ZZI", 1.0)])
+   expectation = Statevector.from_instruction(state_prep).expectation_value(
+       observable
+   )
+
+   measured = QuantumCircuit(3, 3)
+   measured.compose(state_prep, inplace=True)
+   measured.measure(range(3), range(3))
+
+   transpiled = transpile(measured, backend=backend, optimization_level=1)
+
+Use ``--submit`` only when you intentionally want to create an IonQ Cloud job.
+For compilation without shot execution, combine ``--submit`` with ``--dry-run``:
+
+.. code-block:: bash
+
+   IONQ_API_TOKEN=your-token python example/qiskit_core_workflow.py \
+       --backend ionq_qpu.forte-1 --submit --dry-run
+
+For a dry-run job, the example prints the compiled OpenQASM 3 output returned by
+``job.compiled_circuit(lang="qasm3")``. Without ``--dry-run``, it prints the
+regular result counts from ``job.result().get_counts()``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Qiskit IonQ Provider documentation
    Installation <guides/install>
    IonQ API Access <guides/access>
    Submitting circuits <guides/usage>
+   Qiskit core workflows <guides/qiskit_core>
 
 
 .. toctree::

--- a/example/qiskit_core_workflow.py
+++ b/example/qiskit_core_workflow.py
@@ -1,0 +1,120 @@
+"""Qiskit core workflow example for the IonQ provider.
+
+This example keeps cloud submission opt-in. By default it builds a GHZ
+circuit, evaluates a simple local observable with qiskit.quantum_info, and
+transpiles the measured circuit against an IonQ backend target.
+
+Run locally without submitting:
+
+    python example/qiskit_core_workflow.py
+
+Submit only when you intentionally pass --submit and have an IonQ API token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import sys
+
+from qiskit import QuantumCircuit, transpile
+from qiskit.quantum_info import SparsePauliOp, Statevector
+
+# Make the example runnable from a source checkout before qiskit-ionq is installed.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if (REPO_ROOT / "qiskit_ionq").exists():
+    sys.path.insert(0, str(REPO_ROOT))
+
+from qiskit_ionq import IonQProvider
+
+
+def build_ghz_state_prep(num_qubits: int = 3) -> QuantumCircuit:
+    """Return an unmeasured GHZ state-preparation circuit."""
+    if num_qubits < 2:
+        raise ValueError("GHZ examples need at least two qubits.")
+
+    circuit = QuantumCircuit(num_qubits, name=f"ghz_{num_qubits}")
+    circuit.h(0)
+    for target in range(1, num_qubits):
+        circuit.cx(0, target)
+    return circuit
+
+
+def build_ghz_measurement_circuit(num_qubits: int = 3) -> QuantumCircuit:
+    """Return a measured GHZ circuit suitable for backend.run(...)."""
+    circuit = QuantumCircuit(num_qubits, num_qubits, name=f"ghz_{num_qubits}_meas")
+    circuit.compose(build_ghz_state_prep(num_qubits), inplace=True)
+    circuit.measure(range(num_qubits), range(num_qubits))
+    return circuit
+
+
+def local_pair_expectation(circuit: QuantumCircuit) -> float:
+    """Compute <ZZI...> locally for the first two GHZ qubits."""
+    pauli = "ZZ" + ("I" * (circuit.num_qubits - 2))
+    observable = SparsePauliOp.from_list([(pauli, 1.0)])
+    state = Statevector.from_instruction(circuit)
+    return float(state.expectation_value(observable).real)
+
+
+def transpile_for_backend(circuit: QuantumCircuit, backend) -> QuantumCircuit:
+    """Use Qiskit's transpiler with an IonQ backend target."""
+    return transpile(circuit, backend=backend, optimization_level=1)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", default="ionq_simulator")
+    parser.add_argument("--gateset", choices=("qis", "native"), default="qis")
+    parser.add_argument("--qubits", type=int, default=3)
+    parser.add_argument("--shots", type=int, default=100)
+    parser.add_argument("--token", default=os.getenv("IONQ_API_TOKEN"))
+    parser.add_argument(
+        "--submit",
+        action="store_true",
+        help="Submit to IonQ Cloud. Omitted by default to avoid cloud usage.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compile on IonQ Cloud without executing shots. Requires --submit.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    provider = IonQProvider(args.token)
+    backend = provider.get_backend(args.backend, gateset=args.gateset)
+
+    state_prep = build_ghz_state_prep(args.qubits)
+    measured = build_ghz_measurement_circuit(args.qubits)
+    transpiled = transpile_for_backend(measured, backend)
+
+    print(f"Local <ZZI...> expectation: {local_pair_expectation(state_prep):.1f}")
+    print(f"Backend target: {backend.name} ({args.gateset})")
+    print(f"Original ops: {dict(measured.count_ops())}")
+    print(f"Transpiled ops: {dict(transpiled.count_ops())}")
+
+    if not args.submit:
+        print("Not submitting. Pass --submit to run or dry-run on IonQ Cloud.")
+        return
+
+    if not args.token:
+        raise SystemExit(
+            "Set IONQ_API_TOKEN or pass --token before using --submit."
+        )
+
+    job = backend.run(transpiled, shots=args.shots, dry_run=args.dry_run)
+    print(f"Submitted job: {job.job_id()}")
+    job.wait_for_final_state()
+
+    if args.dry_run:
+        print(job.compiled_circuit(lang="qasm3"))
+    else:
+        print(job.result().get_counts())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# PR Draft: Add Qiskit core workflow demo

Closes qiskit-community/qiskit-ionq#93.

## Summary

- Add `example/qiskit_core_workflow.py`, a runnable Qiskit core workflow example for qiskit-ionq.
- Demonstrate local `quantum_info` validation, backend-target transpilation, and opt-in IonQ Cloud submission.
- Add a new docs guide page and include it in the main documentation toctree.

## Why

Issue #93 asks for improved support for Qiskit core libraries or demonstration/example code. This keeps the contribution narrow and avoids overlap with the active IonQSampler/IonQEstimator PR.

## Verification

- `python -m py_compile example\qiskit_core_workflow.py`
- `python example\qiskit_core_workflow.py`
- `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest test\ionq_backend\test_base_backend.py::test_forte_rzz_transpiles_to_zz -q -o addopts=`
- `python -m sphinx -b html docs docs\_build\html`
- `git diff --cached --check`

## Notes

- The example does not submit by default.
- Live IonQ submission is intentionally behind `--submit`; `--dry-run` demonstrates compilation-only mode.
- Not tested against live IonQ Cloud because that requires a real token and may consume account quota.
