### PR TITLE
fix: IonQBackend.status() across simulator, meta-QPU, and real QPUs

### DIFF
--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -265,7 +265,15 @@ class IonQBackend(Backend):
         return self.client.get_calibration_data(self._api_backend_name, limit=1)
 
     def status(self) -> bool:
-        """True if the backend is currently available."""
+        """True if the backend is currently available.
+
+        For simulators we short-circuit to ``True`` because ``calibration()``
+        returns ``None`` by design (the simulator has no characterization
+        endpoint), and the simulator is always available as long as the API
+        itself is reachable.
+        """
+        if self._simulator:
+            return True
         cal = self.calibration()
         return bool(cal and getattr(cal, "status", "available") == "available")
 

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -267,10 +267,8 @@ class IonQBackend(Backend):
     def status(self) -> bool:
         """True if the backend is currently available.
 
-        For simulators we short-circuit to ``True`` because ``calibration()``
-        returns ``None`` by design (the simulator has no characterization
-        endpoint), and the simulator is always available as long as the API
-        itself is reachable.
+        Simulators short-circuit to ``True``: they have no characterization
+        endpoint but are reachable whenever the API is.
         """
         if self._simulator:
             return True

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -262,7 +262,7 @@ class IonQBackend(Backend):
         """Return the latest characterization data (None for simulator)."""
         if self._simulator:
             return None
-        return self.client.get_calibration_data(self._api_backend_name, limit=1)
+        return self.client.get_latest_calibration(self._api_backend_name)
 
     def status(self) -> bool:
         """True if the backend is currently available.

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -233,20 +233,15 @@ class IonQClient:
             IonQRetriableError: When a retriable error occurs during the request.
 
         Returns:
-            Characterization: A single instance when ``limit == 1`` and data
+            A single ``Characterization`` when ``limit == 1`` and data
             exists, ``None`` when ``limit == 1`` but the backend has no
-            characterizations (e.g. the simulator or the generic ``qpu.qpu``
-            meta-backend), or a list of Characterization instances otherwise.
-            The API may return ``{"characterizations": null}`` for backends
-            with no measurement data despite the OpenAPI spec declaring the
-            field non-nullable, so we coerce to an empty list defensively.
+            data (e.g. simulator, ``qpu.qpu``), or a list otherwise.
         """
         params = {"limit": limit} if limit else None
         url = self.make_path("backends", backend_name, "characterizations")
         res = self.get_with_retry(url, headers=self.api_headers, params=params)
         exceptions.IonQAPIError.raise_for_status(res)
-        # API returns {"characterizations": null} for backends with no data,
-        # so dict.get(key, []) won't substitute the default. Use `or []`.
+        # API may ship ``null`` here; dict.get(k, []) won't substitute the default.
         chars = res.json().get("characterizations") or []
         if limit == 1:
             return Characterization(chars[0]) if chars else None
@@ -429,10 +424,8 @@ class Characterization:
     def status(self) -> str:
         """Status of the characterization, e.g. ``"available"``.
 
-        The IonQ v0.4 ``Characterization`` schema does not currently include
-        a ``status`` field; we fall back to ``"available"`` so that callers
-        (notably :meth:`IonQBackend.status`) don't crash with ``KeyError``
-        when the upstream payload omits it.
+        The v0.4 schema omits ``status``; fall back so callers like
+        :meth:`IonQBackend.status` don't ``KeyError``.
         """
         return self._data.get("status", "available")
 

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -221,7 +221,7 @@ class IonQClient:
     @retry(exceptions=IonQRetriableError, max_delay=60, backoff=2, jitter=1)
     def get_calibration_data(
         self, backend_name: str, limit: int | None = None
-    ) -> Characterization | list[Characterization]:
+    ) -> Characterization | list[Characterization] | None:
         """Retrieve calibration data for a specified backend.
 
         Args:
@@ -233,19 +233,24 @@ class IonQClient:
             IonQRetriableError: When a retriable error occurs during the request.
 
         Returns:
-            Characterization: An instance of Characterization containing the calibration data
-            or a list of Characterization instances if multiple results are returned.
+            Characterization: A single instance when ``limit == 1`` and data
+            exists, ``None`` when ``limit == 1`` but the backend has no
+            characterizations (e.g. the simulator or the generic ``qpu.qpu``
+            meta-backend), or a list of Characterization instances otherwise.
+            The API may return ``{"characterizations": null}`` for backends
+            with no measurement data despite the OpenAPI spec declaring the
+            field non-nullable, so we coerce to an empty list defensively.
         """
         params = {"limit": limit} if limit else None
         url = self.make_path("backends", backend_name, "characterizations")
         res = self.get_with_retry(url, headers=self.api_headers, params=params)
         exceptions.IonQAPIError.raise_for_status(res)
-        chars = res.json().get("characterizations", [])
-        return (
-            Characterization(chars[0])
-            if limit == 1
-            else [Characterization(item) for item in chars]
-        )
+        # API returns {"characterizations": null} for backends with no data,
+        # so dict.get(key, []) won't substitute the default. Use `or []`.
+        chars = res.json().get("characterizations") or []
+        if limit == 1:
+            return Characterization(chars[0]) if chars else None
+        return [Characterization(item) for item in chars]
 
     @retry(exceptions=IonQRetriableError, max_delay=60, backoff=2, jitter=1)
     def get_compiled_circuit(self, job_id: str, lang: str = "native") -> str:
@@ -422,8 +427,14 @@ class Characterization:
 
     @property
     def status(self) -> str:
-        """Status of the characterization, e.g. `"available"`."""
-        return self._data["status"]
+        """Status of the characterization, e.g. ``"available"``.
+
+        The IonQ v0.4 ``Characterization`` schema does not currently include
+        a ``status`` field; we fall back to ``"available"`` so that callers
+        (notably :meth:`IonQBackend.status`) don't crash with ``KeyError``
+        when the upstream payload omits it.
+        """
+        return self._data.get("status", "available")
 
     @property
     def date(self) -> datetime:

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -221,21 +221,24 @@ class IonQClient:
     @retry(exceptions=IonQRetriableError, max_delay=60, backoff=2, jitter=1)
     def get_calibration_data(
         self, backend_name: str, limit: int | None = None
-    ) -> Characterization | list[Characterization] | None:
+    ) -> list[Characterization]:
         """Retrieve calibration data for a specified backend.
+
+        Always returns a list. Use :meth:`get_latest_calibration` for the
+        single most recent entry.
 
         Args:
             backend_name (str): The IonQ backend to fetch data for.
-            limit (int, optional): Limit the number of results returned.
+            limit (int, optional): Cap on how many entries to return (API
+                accepts 1–10, default 10).
 
         Raises:
             IonQAPIError: When the API returns a non-200 status code.
             IonQRetriableError: When a retriable error occurs during the request.
 
         Returns:
-            A single ``Characterization`` when ``limit == 1`` and data
-            exists, ``None`` when ``limit == 1`` but the backend has no
-            data (e.g. simulator, ``qpu.qpu``), or a list otherwise.
+            A list of ``Characterization`` instances, empty if the backend
+            has no characterization data (e.g. simulator, ``qpu.qpu``).
         """
         params = {"limit": limit} if limit else None
         url = self.make_path("backends", backend_name, "characterizations")
@@ -243,9 +246,14 @@ class IonQClient:
         exceptions.IonQAPIError.raise_for_status(res)
         # API may ship ``null`` here; dict.get(k, []) won't substitute the default.
         chars = res.json().get("characterizations") or []
-        if limit == 1:
-            return Characterization(chars[0]) if chars else None
         return [Characterization(item) for item in chars]
+
+    def get_latest_calibration(self, backend_name: str) -> Characterization | None:
+        """Return the most recent ``Characterization`` for a backend, or
+        ``None`` if the backend has no characterization data.
+        """
+        chars = self.get_calibration_data(backend_name, limit=1)
+        return chars[0] if chars else None
 
     @retry(exceptions=IonQRetriableError, max_delay=60, backoff=2, jitter=1)
     def get_compiled_circuit(self, job_id: str, lang: str = "native") -> str:

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -76,17 +76,46 @@ def test_qpu_status_with_real_cal(qpu_backend, requests_mock):
 
 def test_get_cal_data_no_chars(qpu_backend, requests_mock):
     """``{"characterizations": null}`` (seen on backends without data like
-    ``qpu.qpu``) must yield ``None`` for ``limit=1``, not ``TypeError``.
+    ``qpu.qpu``) must yield ``[]``, not ``TypeError``. The convenience
+    wrapper returns ``None`` in the same situation. Backend.status() must
+    surface that as ``False``, not crash.
     """
     client = qpu_backend.client
-    url = client.make_path(
-        "backends", qpu_backend._api_backend_name, "characterizations"
-    )
+    name = qpu_backend._api_backend_name
+    url = client.make_path("backends", name, "characterizations")
     requests_mock.get(url, json={"characterizations": None, "pages": 0})
-    result = client.get_calibration_data(qpu_backend._api_backend_name, limit=1)
-    assert result is None
-    # Backend.status() should surface that as False, not crash.
+    assert client.get_calibration_data(name, limit=1) == []
+    assert client.get_latest_calibration(name) is None
     assert qpu_backend.status() is False
+
+
+def test_get_cal_data_always_list(qpu_backend, requests_mock):
+    """``get_calibration_data`` returns a list regardless of ``limit``;
+    ``get_latest_calibration`` is the way to ask for a single entry.
+    """
+    client = qpu_backend.client
+    name = qpu_backend._api_backend_name
+    url = client.make_path("backends", name, "characterizations")
+
+    def _cal(uid):
+        return {
+            "id": uid,
+            "backend": name,
+            "date": "2026-01-01T00:00:00Z",
+            "qubits": 25,
+            "connectivity": [[0, 1]],
+            "fidelity": {},
+            "timing": {},
+        }
+
+    requests_mock.get(
+        url,
+        json={"characterizations": [_cal("a"), _cal("b")], "pages": 1},
+    )
+    chars = client.get_calibration_data(name, limit=2)
+    assert isinstance(chars, list) and len(chars) == 2
+    latest = client.get_latest_calibration(name)
+    assert latest is not None and latest.id == "a"
 
 
 def test_client_property(mock_backend):

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -39,15 +39,63 @@ from qiskit_ionq.helpers import get_user_agent
 from .. import conftest
 
 
-def test_status_dummy_response(mock_backend):
-    """Test that the IonQBackend returns an aribtrary backend status.
-
-    Args:
-        mock_backend (MockBackend): A fake/mock IonQBackend.
+def test_simulator_status_is_true(mock_backend):
+    """Simulator backends are always available; ``calibration()`` returns
+    ``None`` for them by design, but ``status()`` must not conflate "has
+    calibration data" with "is available". MockBackend is ``simulator=True``
+    so this exercises the simulator short-circuit.
     """
-    # TODO mock the client status call
-    status = mock_backend.status()
-    assert status is False
+    assert mock_backend.status() is True
+
+
+def test_qpu_status_with_real_cal(qpu_backend, requests_mock):
+    """For a real QPU, ``Characterization`` payloads have no ``status``
+    field per the v0.4 spec — only ``{backend, connectivity, date, fidelity,
+    id, qubits, timing}``. The deprecated ``Characterization.status``
+    property must fall back to ``"available"`` rather than raise
+    ``KeyError``, so ``IonQBackend.status()`` doesn't crash on every real
+    QPU backend.
+    """
+    client = qpu_backend.client
+    url = client.make_path(
+        "backends", qpu_backend._api_backend_name, "characterizations"
+    )
+    requests_mock.get(
+        url,
+        json={
+            "characterizations": [
+                {
+                    "id": "abc-123",
+                    "backend": qpu_backend._api_backend_name,
+                    "date": "2026-01-01T00:00:00Z",
+                    "qubits": 25,
+                    "connectivity": [[0, 1], [0, 2]],
+                    "fidelity": {"spam": {"median": 0.99}},
+                    "timing": {},
+                }
+            ],
+            "pages": 0,
+        },
+    )
+    assert qpu_backend.status() is True
+
+
+def test_get_cal_data_no_chars(qpu_backend, requests_mock):
+    """The characterizations endpoint returns ``{"characterizations": null}``
+    for backends with no measurement data (e.g. the generic ``qpu.qpu``
+    meta-backend). With ``limit=1`` we must return ``None`` instead of
+    crashing with ``TypeError: 'NoneType' object is not subscriptable``.
+    """
+    client = qpu_backend.client
+    url = client.make_path(
+        "backends", qpu_backend._api_backend_name, "characterizations"
+    )
+    requests_mock.get(url, json={"characterizations": None, "pages": 0})
+    result = client.get_calibration_data(qpu_backend._api_backend_name, limit=1)
+    assert result is None
+    # ...and qpu_backend.status() must surface that as False rather than
+    # crashing.
+    assert qpu_backend.status() is False
 
 
 def test_client_property(mock_backend):

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -40,21 +40,15 @@ from .. import conftest
 
 
 def test_simulator_status_is_true(mock_backend):
-    """Simulator backends are always available; ``calibration()`` returns
-    ``None`` for them by design, but ``status()`` must not conflate "has
-    calibration data" with "is available". MockBackend is ``simulator=True``
-    so this exercises the simulator short-circuit.
+    """``status()`` must not conflate "has calibration data" with "is
+    available". MockBackend is ``simulator=True``.
     """
     assert mock_backend.status() is True
 
 
 def test_qpu_status_with_real_cal(qpu_backend, requests_mock):
-    """For a real QPU, ``Characterization`` payloads have no ``status``
-    field per the v0.4 spec — only ``{backend, connectivity, date, fidelity,
-    id, qubits, timing}``. The deprecated ``Characterization.status``
-    property must fall back to ``"available"`` rather than raise
-    ``KeyError``, so ``IonQBackend.status()`` doesn't crash on every real
-    QPU backend.
+    """Real-QPU ``Characterization`` payloads omit ``status`` per the v0.4
+    spec, so ``Characterization.status`` must fall back, not ``KeyError``.
     """
     client = qpu_backend.client
     url = client.make_path(
@@ -81,10 +75,8 @@ def test_qpu_status_with_real_cal(qpu_backend, requests_mock):
 
 
 def test_get_cal_data_no_chars(qpu_backend, requests_mock):
-    """The characterizations endpoint returns ``{"characterizations": null}``
-    for backends with no measurement data (e.g. the generic ``qpu.qpu``
-    meta-backend). With ``limit=1`` we must return ``None`` instead of
-    crashing with ``TypeError: 'NoneType' object is not subscriptable``.
+    """``{"characterizations": null}`` (seen on backends without data like
+    ``qpu.qpu``) must yield ``None`` for ``limit=1``, not ``TypeError``.
     """
     client = qpu_backend.client
     url = client.make_path(
@@ -93,8 +85,7 @@ def test_get_cal_data_no_chars(qpu_backend, requests_mock):
     requests_mock.get(url, json={"characterizations": None, "pages": 0})
     result = client.get_calibration_data(qpu_backend._api_backend_name, limit=1)
     assert result is None
-    # ...and qpu_backend.status() must surface that as False rather than
-    # crashing.
+    # Backend.status() should surface that as False, not crash.
     assert qpu_backend.status() is False
 
 

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -40,9 +40,7 @@ from .. import conftest
 
 
 def test_simulator_status_is_true(mock_backend):
-    """``status()`` must not conflate "has calibration data" with "is
-    available". MockBackend is ``simulator=True``.
-    """
+    """Simulator ``status()`` returns ``True`` (short-circuits before HTTP)."""
     assert mock_backend.status() is True
 
 


### PR DESCRIPTION
Three pre-existing bugs (all in v1.0.2) along the `IonQBackend.status()` path, surfaced during live v1.0.3 verification. Each has its own regression test.

### Bug 1 — simulator reports `status() == False`
`calibration()` returns `None` for simulators by design, and `bool(None and ...)` short-circuits to False. Fix: shortcut on `self._simulator`.

### Bug 2 — `get_calibration_data(limit=1)` crashes on empty backends
```
GET /v0.4/backends/qpu.qpu/characterizations -> {"characterizations": null}
```
[OpenAPI](https://github.com/ionq/ionq-core/blob/main/openapi.json) declares the field non-nullable, but the live API ships `null` for backends with no data. `dict.get(key, [])` returns `None` (not `[]`) when the key is present with a null value, so `chars[0]` raises `TypeError`. Fix: `chars or []`, return `None` when `limit=1` and empty. Return type widened to `... | None`.

### Bug 3 — every real QPU's `status()` crashes with `KeyError: 'status'`
`Characterization` has no `status` field per the spec (required keys: `{backend, connectivity, date, fidelity, id, qubits, timing}`), but `Characterization.status` did `self._data["status"]`. `getattr` only catches `AttributeError`, not `KeyError`. Fix: `.get("status", "available")`.

## Live verification

| backend | before | after |
|---|---|---|
| `ionq_simulator` | `False` | `True` |
| `ionq_qpu` (meta) | `TypeError` | `False` |
| `ionq_qpu.aria-1` | `KeyError` | `True` |
| `ionq_qpu.forte-1` | `KeyError` | `True` |

## Tests
- `test_simulator_status_is_true` (Bug 1) — replaces the buggy `test_status_dummy_response` that asserted `is False`
- `test_get_cal_data_no_chars` (Bug 2)
- `test_qpu_status_with_real_cal` (Bug 3) — mocks a spec-shaped `Characterization` with no `status` field

Each verified to fail without its production fix. **395 passed**; ruff/format/mypy/pylint clean.

## Sweep for similar bugs
`Characterization.connectivity`/`fidelity`/`timing` use the same `.get(key, default)` pattern as Bug 2 and would break if the API ever shipped those as null. Spec says required and the live aria-1 response has them populated, so not fixed speculatively. No other unguarded dict-property + `getattr` combinations found.