### PR TITLE
feat: mid-circuit measurement via ionq.qasm3.v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The ideal simulator does not produce per-shot data; calling `get_memory()` on a 
 
 ### Mid-circuit measurement
 
-Circuits that reuse a qubit after measuring it — plus mid-circuit `reset` and classical control flow — are submitted automatically as OpenQASM 3 (`ionq.qasm3.v1`); no extra flags needed. Outcomes are reported per declared classical register, matching Qiskit's usual register-split formatting. Single-circuit submissions only; pass `error_mitigation`/`symmetry_verification`, `include_leakage`, or `verbatim` via `job_settings`.
+Circuits that reuse a qubit after measuring it — plus mid-circuit `reset` and classical control flow — are submitted automatically as OpenQASM 3 (`ionq.qasm3.v1`); no extra flags needed. Outcomes are reported per declared classical register, matching Qiskit's usual register-split formatting. Single-circuit submissions only; pass `error_mitigation`/`symmetry_verification`, `include_leakage`, or `verbatim` via `job_settings`. OpenQASM 3 jobs run on the simulator and mid-circuit-measurement-capable QPUs (Tempo); other targets reject them server-side. Classical-register names that collide with OpenQASM 3 reserved words (e.g. `output`, `input`, `measure`) are rejected at submission — rename them.
 
 ```python
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ job = backend.run(qc, dry_run=True)
 job.wait_for_final_state()
 
 native = job.compiled_circuit(lang="native")   # IonQ-native gate JSON (dict)
-qasm3  = job.compiled_circuit(lang="qasm3")    # OpenQASM 3 source (str)
+ore    = job.compiled_circuit(lang="ore")      # lower-level ORE JSON (dict)
 ```
 
 The compiled circuit is fetched from the job's published artifacts (`output.compilation.compiled_circuits`); `lang` is matched against the available format keys (e.g. `"native"` → `ionq.native.v1`). The available formats vary by job and compiler — if the requested one isn't published, `IonQJobError` lists what is. Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
@@ -117,9 +117,11 @@ memory = job.get_memory()       # ['11', '00', '11', '00', ...]
 
 The ideal simulator does not produce per-shot data; calling `get_memory()` on a job submitted without `memory=True` raises `IonQBackendError`.
 
-### Mid-circuit measurement
+### Mid-circuit measurements
 
-Circuits that reuse a qubit after measuring it — plus mid-circuit `reset` and classical control flow — are submitted automatically as OpenQASM 3 (`ionq.qasm3.v1`); no extra flags needed. Outcomes are reported per declared classical register, matching Qiskit's usual register-split formatting. Single-circuit submissions only; pass `error_mitigation`/`symmetry_verification`, `include_leakage`, or `verbatim` via `job_settings`. OpenQASM 3 jobs run on the simulator and mid-circuit-measurement-capable QPUs (Tempo); other targets reject them server-side. Classical-register names that collide with OpenQASM 3 reserved words (e.g. `output`, `input`, `measure`) are rejected at submission — rename them.
+The IonQ provider supports circuits with mid-circuit measurements, qubit reuse after measurement, mid-circuit `reset`, and classical control flow. Outcomes are reported per declared classical register, matching Qiskit's usual register-split formatting. Single-circuit submissions only; pass `error_mitigation`/`symmetry_verification`, `include_leakage`, or `verbatim` via `job_settings`.
+
+Such circuits are submitted automatically as OpenQASM 3 (`ionq.qasm3.v1`) — no extra flags needed. OpenQASM 3 jobs run on the simulator and mid-circuit-measurement-capable QPUs (Tempo); other targets reject them server-side. Classical-register names that collide with OpenQASM 3 reserved words (e.g. `output`, `input`, `measure`) are rejected at submission — rename them.
 
 ```python
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
@@ -130,16 +132,17 @@ result = ClassicalRegister(2, "result")
 qc = QuantumCircuit(qr, mid, result)
 
 qc.h(0)
-qc.measure(0, mid[0])      # mid-circuit measurement
-qc.x(0)
-qc.measure(0, result[0])   # qubit reused after measurement
+qc.measure(0, mid[0])          # mid-circuit measurement
+with qc.if_test((mid, 1)):      # classical control flow on the outcome
+    qc.x(0)
+qc.measure(0, result[0])       # qubit reused after measurement
 qc.x(0)
 qc.measure(0, result[1])
 
 job = backend.run(qc, shots=100, memory=True)
 result = job.result()
-result.get_counts()        # split across registers, e.g. {'00 0': 75, '01 1': 25}
-result.get_memory()        # per-shot, e.g. ['00 0', '01 1', ...]
+result.get_counts()        # split across registers, e.g. {'10 0': 50, '10 1': 50}
+result.get_memory()        # per-shot, e.g. ['10 0', '10 1', ...]
 ```
 
 ### Basis gates and transpilation

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ backend = provider.get_backend("ionq_qpu.forte-1")
 job = backend.run(qc, dry_run=True)
 job.wait_for_final_state()
 
-native_json = job.compiled_circuit(lang="native")   # IonQ-native JSON
-qasm3       = job.compiled_circuit(lang="qasm3")    # OpenQASM 3
+native = job.compiled_circuit(lang="native")   # IonQ-native gate JSON (dict)
+qasm3  = job.compiled_circuit(lang="qasm3")    # OpenQASM 3 source (str)
 ```
 
-Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
+The compiled circuit is fetched from the job's published artifacts (`output.compilation.compiled_circuits`); `lang` is matched against the available format keys (e.g. `"native"` → `ionq.native.v1`). The available formats vary by job and compiler — if the requested one isn't published, `IonQJobError` lists what is. Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
 
 ### Per-shot memory (`memory`)
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,31 @@ memory = job.get_memory()       # ['11', '00', '11', '00', ...]
 
 The ideal simulator does not produce per-shot data; calling `get_memory()` on a job submitted without `memory=True` raises `IonQBackendError`.
 
+### Mid-circuit measurement
+
+Circuits that reuse a qubit after measuring it — plus mid-circuit `reset` and classical control flow — are submitted automatically as OpenQASM 3 (`ionq.qasm3.v1`); no extra flags needed. Outcomes are reported per declared classical register, matching Qiskit's usual register-split formatting. Single-circuit submissions only; pass `error_mitigation`/`symmetry_verification`, `include_leakage`, or `verbatim` via `job_settings`.
+
+```python
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+qr = QuantumRegister(1, "q")
+mid = ClassicalRegister(1, "mid")
+result = ClassicalRegister(2, "result")
+qc = QuantumCircuit(qr, mid, result)
+
+qc.h(0)
+qc.measure(0, mid[0])      # mid-circuit measurement
+qc.x(0)
+qc.measure(0, result[0])   # qubit reused after measurement
+qc.x(0)
+qc.measure(0, result[1])
+
+job = backend.run(qc, shots=100, memory=True)
+result = job.result()
+result.get_counts()        # split across registers, e.g. {'00 0': 75, '01 1': 25}
+result.get_memory()        # per-shot, e.g. ['00 0', '01 1', ...]
+```
+
 ### Basis gates and transpilation
 
 The IonQ provider provides access to the full IonQ Cloud backend, which includes its own transpilation and compilation pipeline. As such, IonQ provider backends have a broad set of "basis gates" that they will accept — effectively anything the IonQ API will accept. The current supported gates can be found [on our docs site](https://docs.ionq.com/#tag/quantum_programs).

--- a/qiskit_ionq/constants.py
+++ b/qiskit_ionq/constants.py
@@ -71,4 +71,18 @@ class ErrorMitigation(enum.Enum):
     NO_DEBIASING = {"debiasing": False}
 
 
-__all__ = ["APIJobStatus", "JobStatusMap", "ErrorMitigation"]
+class ResultFormat(str, enum.Enum):
+    """Format keys for the id-addressed v2 result artifacts in a job's
+    ``results`` map (fetched via ``GET /jobs/{id}/artifacts/{id}``).
+
+    Subclasses ``str`` so a member is usable directly as a dict key, e.g.
+    ``results.get(ResultFormat.SHOTS_V2)`` (``enum.StrEnum`` is 3.11+; the
+    repo floor is 3.10).
+    """
+
+    SHOTS_V2 = "ionq.result.shots.json.v2"
+    HISTOGRAM_V2 = "ionq.result.histogram.json.v2"
+    PROBABILITIES_V2 = "ionq.result.probabilities.json.v2"
+
+
+__all__ = ["APIJobStatus", "JobStatusMap", "ErrorMitigation", "ResultFormat"]

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -50,6 +50,7 @@ from qiskit import __version__ as qiskit_version
 from qiskit.user_config import get_config
 from qiskit.circuit import (
     controlledgate as q_cgates,
+    ControlFlowOp,
     QuantumCircuit,
     QuantumRegister,
     ClassicalRegister,
@@ -162,13 +163,13 @@ def circuit_requires_qasm3(input_circuit: QuantumCircuit) -> bool:
     """True for mid-circuit measurement, reset, or control flow (not
     expressible as a flat v1 gate list, so submitted as OpenQASM 3).
     """
-    control_flow = {"if_else", "while_loop", "for_loop", "switch_case"}
     measured: set[int] = set()
     for inst in input_circuit.data:
-        name = inst.operation.name
+        operation = inst.operation
+        name = operation.name
         if name in ("barrier", "delay"):
             continue
-        if name in control_flow:
+        if isinstance(operation, ControlFlowOp):
             return True
         if name == "reset":
             return True
@@ -476,7 +477,7 @@ def _qasm3_data(circuit: QuantumCircuit) -> str:
     if renamed:
         raise ionq_exceptions.IonQJobError(
             f"Classical register name(s) {renamed} are OpenQASM 3 reserved "
-            "words and get renamed on export; rename them and resubmit."
+            "words; rename them and resubmit."
         )
     return data
 
@@ -594,8 +595,8 @@ def qiskit_to_ionq(
         if multi_circuit:
             raise ionq_exceptions.IonQJobError(
                 "Mid-circuit measurement, reset, and classical control flow are "
-                "only supported for single-circuit submissions. Submit each such "
-                "circuit as its own job."
+                "only supported for single-circuit submissions. Submit such "
+                "circuits in separate jobs."
             )
         return _qiskit_to_qasm3_json(
             circuit,

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -157,6 +157,33 @@ def native_2q_gate(value: str | None) -> Literal["ms", "zz"] | None:
     return None
 
 
+def circuit_requires_qasm3(input_circuit: QuantumCircuit) -> bool:
+    """Whether a circuit needs the ``ionq.qasm3.v1`` path.
+
+    The flat ``ionq.circuit.v1`` gate list can't express mid-circuit
+    measurement (an op on a qubit after it was measured), mid-circuit
+    ``reset``, or classical control flow; such circuits go out as OpenQASM 3.
+    """
+    control_flow = {"if_else", "while_loop", "for_loop", "switch_case"}
+    measured: set[int] = set()
+    for inst in input_circuit.data:
+        operation = inst.operation
+        name = operation.name
+        if name in ("barrier", "delay"):
+            continue
+        if name in control_flow or getattr(operation, "condition", None) is not None:
+            return True
+        if name == "reset":
+            return True
+        qubit_indices = [input_circuit.qubits.index(q) for q in inst.qubits]
+        if name == "measure":
+            measured.update(qubit_indices)
+            continue
+        if measured.intersection(qubit_indices):
+            return True
+    return False
+
+
 def qiskit_circ_to_ionq_circ(
     input_circuit: QuantumCircuit,
     gateset: Literal["qis", "native"] = "qis",
@@ -435,6 +462,95 @@ def decompress_metadata_string(
     return json.loads(decompressed)
 
 
+def _to_qasm3(circuit: QuantumCircuit) -> str:
+    """OpenQASM 3 string for ``ionq.qasm3.v1`` submission (lazy qasm3 import)."""
+    from qiskit.qasm3 import (  # pylint: disable=import-outside-toplevel
+        dumps as _qasm3_dumps,
+    )
+
+    return _qasm3_dumps(circuit)
+
+
+def _qiskit_to_qasm3_json(  # pylint: disable=too-many-positional-arguments
+    circuit: QuantumCircuit,
+    backend,
+    backend_name: str,
+    passed_args: dict,
+    extra_query_params: dict,
+    extra_metadata: dict,
+) -> str:
+    """Build the ``ionq.qasm3.v1`` payload for a single circuit.
+
+    Used for mid-circuit measurement / reset / control-flow circuits (see
+    :func:`circuit_requires_qasm3`). ``input`` carries the OpenQASM 3 string
+    and qubit count; results return per declared classical register.
+    """
+    qiskit_header = compress_to_metadata_string(
+        {
+            "memory_slots": circuit.num_clbits,
+            "global_phase": circuit.global_phase,
+            "n_qubits": circuit.num_qubits,
+            "name": circuit.name,
+            "creg_sizes": get_register_sizes_and_labels(circuit.cregs)[0],
+            "clbit_labels": get_register_sizes_and_labels(circuit.cregs)[1],
+            "qreg_sizes": get_register_sizes_and_labels(circuit.qregs)[0],
+            "qubit_labels": get_register_sizes_and_labels(circuit.qregs)[1],
+            **({"metadata": circuit.metadata} if circuit.metadata else {}),
+        }
+    )
+
+    ionq_json: dict[str, Any] = {
+        "type": "ionq.qasm3.v1",
+        "backend": backend_name,
+        "shots": passed_args.get("shots"),
+        "name": passed_args.get("name") or circuit.name,
+        "input": {
+            "qubits": circuit.num_qubits,
+            "data": _to_qasm3(circuit),
+        },
+        **(
+            {"session_id": passed_args["session_id"]}
+            if passed_args.get("session_id") is not None
+            else {}
+        ),
+        "metadata": {
+            "shots": str(passed_args.get("shots")),
+            "sampler_seed": str(passed_args.get("sampler_seed")),
+            "qiskit_header": qiskit_header,
+            "user_agent": get_user_agent(),
+        },
+    }
+
+    # simulator noise model (matches the v1 path)
+    if backend_name == "simulator":
+        ionq_json["noise"] = {
+            "model": passed_args.get("noise_model") or backend.options.noise_model,
+            "seed": backend.options.sampler_seed,
+        }
+
+    # Start from user job_settings (so compilation, include_leakage, verbatim,
+    # error_mitigation.symmetry_verification, ... pass through), then layer the
+    # ErrorMitigation enum onto any error_mitigation block.
+    settings: dict[str, Any] = dict(passed_args.get("job_settings") or {})
+    error_mitigation = passed_args.get("error_mitigation") or backend.options.get(
+        "error_mitigation"
+    )
+    if isinstance(error_mitigation, ErrorMitigation):
+        em_block = dict(settings.get("error_mitigation") or {})
+        em_block.update(error_mitigation.value)
+        settings["error_mitigation"] = em_block
+    if settings:
+        ionq_json["settings"] = settings
+
+    if passed_args.get("dry_run"):
+        ionq_json["dry_run"] = True
+
+    ionq_json.update(extra_query_params)
+    ionq_json["metadata"].update(extra_metadata)
+
+    return json.dumps(ionq_json, cls=SafeEncoder)
+
+
 def qiskit_to_ionq(
     circuit,
     backend,
@@ -458,10 +574,32 @@ def qiskit_to_ionq(
     extra_query_params = extra_query_params or {}
     extra_metadata = extra_metadata or {}
 
+    backend_name = backend.name[5:] if backend.name.startswith("ionq") else backend.name
+
+    multi_circuit = isinstance(circuit, (list, tuple))
+
+    # MCM, reset, and control flow can't be expressed in the flat
+    # ionq.circuit.v1 gate list; route them to ionq.qasm3.v1.
+    circuits_to_check = circuit if multi_circuit else [circuit]
+    if any(circuit_requires_qasm3(c) for c in circuits_to_check):
+        if multi_circuit:
+            raise ionq_exceptions.IonQJobError(
+                "Mid-circuit measurement, reset, and classical control flow are "
+                "only supported for single-circuit submissions. Submit each such "
+                "circuit as its own job."
+            )
+        return _qiskit_to_qasm3_json(
+            circuit,
+            backend,
+            backend_name,
+            passed_args,
+            extra_query_params,
+            extra_metadata,
+        )
+
     # build the (multi-)circuit block
     ionq_circs: list[Any] | Any = []
     meas_map: list[int] | None = None
-    multi_circuit = isinstance(circuit, (list, tuple))
 
     if multi_circuit:
         for circ in circuit:
@@ -536,7 +674,6 @@ def qiskit_to_ionq(
         input_block["circuit"] = ionq_circs
 
     # top-level fields
-    backend_name = backend.name[5:] if backend.name.startswith("ionq") else backend.name
     ionq_json: dict[str, Any] = {
         "type": "ionq.multi-circuit.v1" if multi_circuit else "ionq.circuit.v1",
         "backend": backend_name,
@@ -768,6 +905,7 @@ def warn_bad_transpile_level():
 __all__ = [
     "qiskit_to_ionq",
     "qiskit_circ_to_ionq_circ",
+    "circuit_requires_qasm3",
     "compress_to_metadata_string",
     "decompress_metadata_string",
     "get_user_agent",

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -159,11 +159,8 @@ def native_2q_gate(value: str | None) -> Literal["ms", "zz"] | None:
 
 
 def circuit_requires_qasm3(input_circuit: QuantumCircuit) -> bool:
-    """Whether a circuit needs the ``ionq.qasm3.v1`` path.
-
-    The flat ``ionq.circuit.v1`` gate list can't express mid-circuit
-    measurement (an op on a qubit after it was measured), mid-circuit
-    ``reset``, or classical control flow; such circuits go out as OpenQASM 3.
+    """True for mid-circuit measurement, reset, or control flow (not
+    expressible as a flat v1 gate list, so submitted as OpenQASM 3).
     """
     control_flow = {"if_else", "while_loop", "for_loop", "switch_case"}
     measured: set[int] = set()
@@ -463,13 +460,11 @@ def decompress_metadata_string(
 
 
 def _qasm3_data(circuit: QuantumCircuit) -> str:
-    """OpenQASM 3 string for ``ionq.qasm3.v1`` submission.
+    """OpenQASM 3 for submission.
 
-    Rejects circuits whose classical-register names ``qiskit.qasm3.dumps``
-    renames to dodge OpenQASM 3 reserved words (``output`` -> ``output_0``):
-    the server keys per-register results by the emitted name while the decoder
-    maps by the circuit's names, so a silent rename would zero out that
-    register. Failing fast beats wrong counts.
+    Rejects cregs that ``dumps`` renames to dodge reserved words
+    (``output`` -> ``output_0``); the rename would misalign per-register
+    results decoded by the original name.
     """
     from qiskit.qasm3 import (  # pylint: disable=import-outside-toplevel
         dumps as _qasm3_dumps,
@@ -480,21 +475,15 @@ def _qasm3_data(circuit: QuantumCircuit) -> str:
     renamed = [creg.name for creg in circuit.cregs if creg.name not in emitted]
     if renamed:
         raise ionq_exceptions.IonQJobError(
-            f"Classical register name(s) {renamed} collide with OpenQASM 3 "
-            "reserved words and are renamed on export, which would corrupt "
-            "per-register results. Rename the register(s) and resubmit."
+            f"Classical register name(s) {renamed} are OpenQASM 3 reserved "
+            "words and get renamed on export; rename them and resubmit."
         )
     return data
 
 
 def _build_settings(passed_args: dict, backend) -> dict[str, Any]:
-    """Assemble the job ``settings`` block (shared by all submission formats).
-
-    Starts from the user's ``job_settings`` so the full v0.4 surface
-    (compilation, include_leakage, verbatim, error_mitigation.*, ...) passes
-    through, then merges the :class:`ErrorMitigation` enum into the
-    ``error_mitigation`` sub-block so e.g. a user-set ``symmetry_verification``
-    survives alongside ``debiasing``.
+    """Build ``settings`` from ``job_settings``, merging the ErrorMitigation
+    enum into ``error_mitigation``.
     """
     settings: dict[str, Any] = dict(passed_args.get("job_settings") or {})
     error_mitigation = passed_args.get("error_mitigation") or backend.options.get(
@@ -515,12 +504,7 @@ def _qiskit_to_qasm3_json(  # pylint: disable=too-many-positional-arguments
     extra_query_params: dict,
     extra_metadata: dict,
 ) -> str:
-    """Build the ``ionq.qasm3.v1`` payload for a single circuit.
-
-    Used for mid-circuit measurement / reset / control-flow circuits (see
-    :func:`circuit_requires_qasm3`). ``input`` carries the OpenQASM 3 string
-    and qubit count; results return per declared classical register.
-    """
+    """Build the ``ionq.qasm3.v1`` payload (OpenQASM 3 input) for one circuit."""
     qiskit_header = compress_to_metadata_string(
         {
             "memory_slots": circuit.num_clbits,
@@ -557,7 +541,7 @@ def _qiskit_to_qasm3_json(  # pylint: disable=too-many-positional-arguments
         },
     }
 
-    # simulator noise model (matches the v1 path)
+    # simulator noise model
     if backend_name == "simulator":
         ionq_json["noise"] = {
             "model": passed_args.get("noise_model") or backend.options.noise_model,
@@ -604,8 +588,7 @@ def qiskit_to_ionq(
 
     multi_circuit = isinstance(circuit, (list, tuple))
 
-    # MCM, reset, and control flow can't be expressed in the flat
-    # ionq.circuit.v1 gate list; route them to ionq.qasm3.v1.
+    # Route circuits the v1 gate list can't express (see circuit_requires_qasm3).
     circuits_to_check = circuit if multi_circuit else [circuit]
     if any(circuit_requires_qasm3(c) for c in circuits_to_check):
         if multi_circuit:

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -465,12 +465,11 @@ def decompress_metadata_string(
 def _qasm3_data(circuit: QuantumCircuit) -> str:
     """OpenQASM 3 string for ``ionq.qasm3.v1`` submission.
 
-    Rejects circuits whose classical-register names get renamed on export:
-    ``qiskit.qasm3.dumps`` rewrites names that collide with OpenQASM 3 reserved
-    words (e.g. ``output`` -> ``output_0``). The server keys per-register
-    results by the emitted name while the result decoder maps by the circuit's
-    register names, so a silent rename would zero out that register's outcomes.
-    Failing fast with the offending names is better than wrong counts.
+    Rejects circuits whose classical-register names ``qiskit.qasm3.dumps``
+    renames to dodge OpenQASM 3 reserved words (``output`` -> ``output_0``):
+    the server keys per-register results by the emitted name while the decoder
+    maps by the circuit's names, so a silent rename would zero out that
+    register. Failing fast beats wrong counts.
     """
     from qiskit.qasm3 import (  # pylint: disable=import-outside-toplevel
         dumps as _qasm3_dumps,

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -32,6 +32,7 @@ to IonQ REST API compatible values.
 from __future__ import annotations
 
 import json
+import re
 import gzip
 import base64
 import platform
@@ -167,11 +168,10 @@ def circuit_requires_qasm3(input_circuit: QuantumCircuit) -> bool:
     control_flow = {"if_else", "while_loop", "for_loop", "switch_case"}
     measured: set[int] = set()
     for inst in input_circuit.data:
-        operation = inst.operation
-        name = operation.name
+        name = inst.operation.name
         if name in ("barrier", "delay"):
             continue
-        if name in control_flow or getattr(operation, "condition", None) is not None:
+        if name in control_flow:
             return True
         if name == "reset":
             return True
@@ -462,13 +462,50 @@ def decompress_metadata_string(
     return json.loads(decompressed)
 
 
-def _to_qasm3(circuit: QuantumCircuit) -> str:
-    """OpenQASM 3 string for ``ionq.qasm3.v1`` submission (lazy qasm3 import)."""
+def _qasm3_data(circuit: QuantumCircuit) -> str:
+    """OpenQASM 3 string for ``ionq.qasm3.v1`` submission.
+
+    Rejects circuits whose classical-register names get renamed on export:
+    ``qiskit.qasm3.dumps`` rewrites names that collide with OpenQASM 3 reserved
+    words (e.g. ``output`` -> ``output_0``). The server keys per-register
+    results by the emitted name while the result decoder maps by the circuit's
+    register names, so a silent rename would zero out that register's outcomes.
+    Failing fast with the offending names is better than wrong counts.
+    """
     from qiskit.qasm3 import (  # pylint: disable=import-outside-toplevel
         dumps as _qasm3_dumps,
     )
 
-    return _qasm3_dumps(circuit)
+    data = _qasm3_dumps(circuit)
+    emitted = set(re.findall(r"\bbit(?:\[\d+\])?\s+(\w+)\s*;", data))
+    renamed = [creg.name for creg in circuit.cregs if creg.name not in emitted]
+    if renamed:
+        raise ionq_exceptions.IonQJobError(
+            f"Classical register name(s) {renamed} collide with OpenQASM 3 "
+            "reserved words and are renamed on export, which would corrupt "
+            "per-register results. Rename the register(s) and resubmit."
+        )
+    return data
+
+
+def _build_settings(passed_args: dict, backend) -> dict[str, Any]:
+    """Assemble the job ``settings`` block (shared by all submission formats).
+
+    Starts from the user's ``job_settings`` so the full v0.4 surface
+    (compilation, include_leakage, verbatim, error_mitigation.*, ...) passes
+    through, then merges the :class:`ErrorMitigation` enum into the
+    ``error_mitigation`` sub-block so e.g. a user-set ``symmetry_verification``
+    survives alongside ``debiasing``.
+    """
+    settings: dict[str, Any] = dict(passed_args.get("job_settings") or {})
+    error_mitigation = passed_args.get("error_mitigation") or backend.options.get(
+        "error_mitigation"
+    )
+    if isinstance(error_mitigation, ErrorMitigation):
+        em_block = dict(settings.get("error_mitigation") or {})
+        em_block.update(error_mitigation.value)
+        settings["error_mitigation"] = em_block
+    return settings
 
 
 def _qiskit_to_qasm3_json(  # pylint: disable=too-many-positional-arguments
@@ -506,7 +543,7 @@ def _qiskit_to_qasm3_json(  # pylint: disable=too-many-positional-arguments
         "name": passed_args.get("name") or circuit.name,
         "input": {
             "qubits": circuit.num_qubits,
-            "data": _to_qasm3(circuit),
+            "data": _qasm3_data(circuit),
         },
         **(
             {"session_id": passed_args["session_id"]}
@@ -528,17 +565,7 @@ def _qiskit_to_qasm3_json(  # pylint: disable=too-many-positional-arguments
             "seed": backend.options.sampler_seed,
         }
 
-    # Start from user job_settings (so compilation, include_leakage, verbatim,
-    # error_mitigation.symmetry_verification, ... pass through), then layer the
-    # ErrorMitigation enum onto any error_mitigation block.
-    settings: dict[str, Any] = dict(passed_args.get("job_settings") or {})
-    error_mitigation = passed_args.get("error_mitigation") or backend.options.get(
-        "error_mitigation"
-    )
-    if isinstance(error_mitigation, ErrorMitigation):
-        em_block = dict(settings.get("error_mitigation") or {})
-        em_block.update(error_mitigation.value)
-        settings["error_mitigation"] = em_block
+    settings = _build_settings(passed_args, backend)
     if settings:
         ionq_json["settings"] = settings
 
@@ -702,14 +729,7 @@ def qiskit_to_ionq(
         }
 
     # settings / error mitigation
-    settings: dict[str, Any] = dict(passed_args.get("job_settings") or {})
-    error_mitigation = passed_args.get("error_mitigation") or backend.options.get(
-        "error_mitigation"
-    )
-
-    if isinstance(error_mitigation, ErrorMitigation):
-        settings["error_mitigation"] = error_mitigation.value
-
+    settings = _build_settings(passed_args, backend)
     if settings:
         ionq_json["settings"] = settings
 

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -256,45 +256,6 @@ class IonQClient:
         return chars[0] if chars else None
 
     @retry(exceptions=IonQRetriableError, max_delay=60, backoff=2, jitter=1)
-    def get_compiled_circuit(self, job_id: str, lang: str = "native") -> str:
-        """Retrieve the server-compiled circuit for a job.
-
-        Hits ``GET /v0.4/jobs/{UUID}/circuits/{lang}``, which is populated by the
-        IonQ Cloud compiler-as-a-service for jobs submitted with ``dry_run=True``
-        (and, for fully-executed jobs, the post-compilation circuit actually run
-        on hardware).
-
-        Args:
-            job_id (str): The ID of the job whose compiled circuit to fetch.
-            lang (str): Output language. ``"native"`` (default) returns the
-                IonQ-native gate JSON; ``"qasm3"`` returns OpenQASM 3 source.
-                Other values may be accepted depending on organization
-                entitlement; consult the IonQ API reference for the current
-                set. Unsupported or non-entitled values are rejected by the
-                API with a ``4xx`` response.
-
-        Raises:
-            IonQAPIError: When the API returns a non-2xx status code (this
-                covers both unsupported ``lang`` values and per-organization
-                entitlement rejections).
-            IonQRetriableError: When a retriable error occurs during the request.
-
-        Returns:
-            str: The compiled circuit as a string. For ``lang="qasm3"`` this is
-            an OpenQASM 3 program; for ``lang="native"`` this is the IonQ JSON
-            circuit representation in native gates.
-        """
-        req_path = self.make_path("jobs", job_id, "circuits", lang)
-        res = self.get_with_retry(req_path, headers=self.api_headers)
-        exceptions.IonQAPIError.raise_for_status(res)
-        # The API returns a JSON-encoded string body; .json() unwraps the outer
-        # quotes and returns a plain Python str.
-        try:
-            return res.json()
-        except ValueError:
-            return res.text
-
-    @retry(exceptions=IonQRetriableError, max_delay=60, backoff=2, jitter=1)
     def get_results(
         self,
         results_url: str,

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -308,16 +308,7 @@ class IonQClient:
         artifact_id: str,
         extra_query_params: dict | None = None,
     ) -> dict:
-        """Retrieve a result artifact from ``/jobs/{id}/artifacts/{aid}``.
-
-        Fetches the per-register shots (``ionq.result.shots.json.v2``) for
-        mid-circuit measurement jobs, whose ``results`` block advertises an
-        artifact ``id`` rather than a ``url``.
-
-        Raises:
-            IonQAPIError: When the API returns a non-200 status code.
-            IonQRetriableError: When a retriable error occurs during the request.
-        """
+        """GET a result artifact by id (``/jobs/{id}/artifacts/{aid}``)."""
         req_path = self.make_path("jobs", job_id, "artifacts", artifact_id)
         res = self.get_with_retry(
             req_path, headers=self.api_headers, params=extra_query_params or None

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -340,6 +340,30 @@ class IonQClient:
         # Use json.loads with object_pairs_hook to maintain order of JSON keys
         return json.loads(res.text, object_pairs_hook=OrderedDict)
 
+    @retry(exceptions=IonQRetriableError, max_delay=60, backoff=2, jitter=1)
+    def get_artifact(
+        self,
+        job_id: str,
+        artifact_id: str,
+        extra_query_params: dict | None = None,
+    ) -> dict:
+        """Retrieve a result artifact from ``/jobs/{id}/artifacts/{aid}``.
+
+        Fetches the per-register shots (``ionq.result.shots.json.v2``) for
+        mid-circuit measurement jobs, whose ``results`` block advertises an
+        artifact ``id`` rather than a ``url``.
+
+        Raises:
+            IonQAPIError: When the API returns a non-200 status code.
+            IonQRetriableError: When a retriable error occurs during the request.
+        """
+        req_path = self.make_path("jobs", job_id, "artifacts", artifact_id)
+        res = self.get_with_retry(
+            req_path, headers=self.api_headers, params=extra_query_params or None
+        )
+        exceptions.IonQAPIError.raise_for_status(res)
+        return json.loads(res.text, object_pairs_hook=OrderedDict)
+
     def estimate_job(
         self,
         *,

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -307,13 +307,20 @@ class IonQClient:
         job_id: str,
         artifact_id: str,
         extra_query_params: dict | None = None,
-    ) -> dict:
-        """GET a result artifact by id (``/jobs/{id}/artifacts/{aid}``)."""
+    ) -> dict | list | str | bytes:
+        """GET a result artifact by id (``/jobs/{id}/artifacts/{aid}``).
+
+        JSON artifacts decode to order-preserving objects; binary ones (the
+        ``ionq.mir.v1`` compiled circuit, ``application/octet-stream``) return
+        as raw ``bytes``.
+        """
         req_path = self.make_path("jobs", job_id, "artifacts", artifact_id)
         res = self.get_with_retry(
             req_path, headers=self.api_headers, params=extra_query_params or None
         )
         exceptions.IonQAPIError.raise_for_status(res)
+        if "octet-stream" in res.headers.get("Content-Type", "").lower():
+            return res.content
         return json.loads(res.text, object_pairs_hook=OrderedDict)
 
     def estimate_job(

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -207,6 +207,10 @@ class IonQJob(JobV1):
         self._execution_time = None
         self._dry_run: bool = False
         self._results_urls: dict[str, str | None] = {}
+        # ionq.qasm3.v1 (mid-circuit measurement) jobs return per-register
+        # shots from a separate artifact; set in status() from the job type.
+        self._is_qasm3: bool = False
+        self._shots_artifact_id: str | None = None
         self._metadata: dict[str, Any] = {}
 
         if passed_args is not None:
@@ -411,12 +415,17 @@ class IonQJob(JobV1):
                     "job.compiled_circuit(lang='native' or 'qasm3') to "
                     "retrieve the compiled circuit instead."
                 )
-            response = self._client.get_results(
-                results_url=self._results_urls.get("probabilities", ""),
-                sharpen=sharpen,
-                extra_query_params=extra_query_params,
-            )
-            self._result = self._format_result(response)
+            if self._is_qasm3:
+                self._result = self._format_result_qasm3(
+                    self._fetch_qasm3_shots(extra_query_params)
+                )
+            else:
+                response = self._client.get_results(
+                    results_url=self._results_urls.get("probabilities", ""),
+                    sharpen=sharpen,
+                    extra_query_params=extra_query_params,
+                )
+                self._result = self._format_result(response)
 
         return self._result
 
@@ -479,6 +488,10 @@ class IonQJob(JobV1):
 
             self._num_qubits = self._first_of(stats, "qubits", default=0)
 
+            # Mid-circuit measurement jobs come back as ionq.qasm3.v1 and
+            # carry per-register shot-wise results in a dedicated artifact.
+            self._is_qasm3 = response.get("type") == "ionq.qasm3.v1"
+
             # Dry-run jobs have results=null; non-dry-run may also be null mid-rollout.
             if not self._dry_run:
                 results = response.get("results") or {}
@@ -487,6 +500,8 @@ class IonQJob(JobV1):
                     for k, v in results.items()
                     if isinstance(v, dict) and isinstance(v.get("url"), str)
                 }
+                if self._is_qasm3:
+                    self._shots_artifact_id = self._find_shots_v2_id(results)
 
             # Classical-bit maps per circuit
             def _meas_map_from_header(header_dict, fallback_nq):
@@ -640,6 +655,108 @@ class IonQJob(JobV1):
             url = shots.get("url") if isinstance(shots, dict) else None
             per_circuit.append(self._fetch_raw_shots(url, ctx=f"child {child_id}"))
         return per_circuit
+
+    @staticmethod
+    def _find_shots_v2_id(results: dict) -> str | None:
+        """Return the ``ionq.result.shots.json.v2`` artifact id, if advertised.
+
+        The per-register shot-wise format is keyed by an artifact ``id``
+        (fetched via ``/jobs/{id}/artifacts/{aid}``) rather than a ``url``.
+        """
+        for value in results.values():
+            if isinstance(value, dict) and str(value.get("format", "")).endswith(
+                "shots.json.v2"
+            ):
+                return value.get("id")
+        return None
+
+    def _fetch_qasm3_shots(self, extra_query_params: dict | None = None) -> list:
+        """Fetch the per-register shots array for a qasm3 (MCM) job.
+
+        Raises:
+            IonQJobError: If the job advertised no v2 shots artifact.
+        """
+        if not self._shots_artifact_id:
+            raise exceptions.IonQJobError(
+                f"Job {self._job_id} reported no per-register shots artifact; "
+                "cannot build mid-circuit measurement results."
+            )
+        assert self._job_id is not None
+        payload = self._client.get_artifact(
+            self._job_id,
+            self._shots_artifact_id,
+            extra_query_params=extra_query_params,
+        )
+        if isinstance(payload, dict) and "shots" in payload:
+            return payload["shots"]
+        return payload
+
+    def _format_result_qasm3(self, shots: list):
+        """Translate per-register shot-wise (qasm3/MCM) results into a Result.
+
+        Each shot is ``{"registers": {name: [bit, ...], ...}}``. The user's
+        declared registers are folded into one integer per shot via the
+        header's ``clbit_labels``, so ``get_counts()``/``get_memory()`` split
+        across registers as usual. The system-appended ``output_all`` register
+        is excluded.
+        """
+        backend = self.backend()
+        success = self._status == jobstatus.JobStatus.DONE
+        metadata = self._metadata.get("metadata") or {}
+        decoded = decompress_metadata_string(metadata.get("qiskit_header"))
+        # Single-circuit, so the header is a lone dict; tolerate a list.
+        if isinstance(decoded, list):
+            decoded = decoded[0] if decoded else {}
+        header = decoded if isinstance(decoded, dict) else {}
+
+        shots = shots or []
+        clbit_labels = header.get("clbit_labels") or []
+        # Zero-padded MSB-left binary (as the v1 path) so Result.get_counts()
+        # splits across registers via the header's creg_sizes.
+        width = header.get("memory_slots") or len(clbit_labels)
+
+        counts: dict[str, int] = {}
+        memory: list[str] = []
+        for shot in shots:
+            registers = shot.get("registers", {}) if isinstance(shot, dict) else {}
+            value = 0
+            for index, label in enumerate(clbit_labels):
+                name, bit = label[0], label[1]
+                bits = registers.get(name)
+                if bits is not None and bit < len(bits) and int(bits[bit]):
+                    value |= 1 << index
+            key = format(value, f"0{width}b") if width else "0"
+            memory.append(key)
+            counts[key] = counts.get(key, 0) + 1
+
+        total = len(shots)
+        probabilities = {k: v / total for k, v in counts.items()} if total else {}
+
+        job_result = [
+            {
+                "data": {
+                    "counts": counts,
+                    "memory": memory if self.memory else None,
+                    "probabilities": probabilities,
+                    "metadata": header,
+                },
+                "shots": total,
+                "header": header,
+                "success": success,
+            }
+        ]
+
+        return Result.from_dict(
+            {
+                "results": job_result,
+                "job_id": self.job_id(),
+                "backend_name": backend.name,
+                "backend_version": backend.backend_version,
+                "qobj_id": metadata.get("qobj_id"),
+                "success": success,
+                "time_taken": self._execution_time,
+            }
+        )
 
     def _format_result(self, data):
         """Translate IonQ result format into a Qiskit `Result` instance.

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -270,13 +270,14 @@ class IonQJob(JobV1):
             None,
         )
 
-    def compiled_circuit(self, lang: str = "native") -> dict | list | str:
+    def compiled_circuit(self, lang: str = "native") -> dict | list | str | bytes:
         """Fetch the server-compiled circuit, parsed from its published artifact.
 
-        ``lang`` is a short name (``"native"``) or exact format key matched
-        against ``output.compilation.compiled_circuits``; raises
-        ``IonQJobError`` if none match. Returns a ``dict`` (native/IR JSON) or
-        ``str`` (OpenQASM).
+        ``lang`` is a short name -- ``"native"`` or ``"ore"`` (QIS jobs),
+        ``"mir"`` (OpenQASM 3 jobs) -- or an exact format key, matched against
+        ``output.compilation.compiled_circuits``; raises ``IonQJobError`` if
+        none match. Returns a ``dict``/``list`` for JSON formats or ``bytes``
+        for binary ones (``ionq.mir.v1``).
         """
         self.status()
         if self._status not in jobstatus.JOB_FINAL_STATES:
@@ -421,7 +422,7 @@ class IonQJob(JobV1):
                 raise exceptions.IonQJobError(
                     f"Job {self._job_id} was submitted with dry_run=True; "
                     "no measurement results are produced. Use "
-                    "job.compiled_circuit(lang='native' or 'qasm3') to "
+                    "job.compiled_circuit(...) to "
                     "retrieve the compiled circuit instead."
                 )
             if self._is_qasm3:
@@ -509,7 +510,10 @@ class IonQJob(JobV1):
                     if isinstance(v, dict) and isinstance(v.get("url"), str)
                 }
                 if self._is_qasm3:
-                    self._shots_artifact_id = self._find_shots_v2_id(results)
+                    shots = results.get(constants.ResultFormat.SHOTS_V2)
+                    self._shots_artifact_id = (
+                        shots.get("id") if isinstance(shots, dict) else None
+                    )
 
             # Classical-bit maps per circuit
             def _meas_map_from_header(header_dict, fallback_nq):
@@ -663,16 +667,6 @@ class IonQJob(JobV1):
             url = shots.get("url") if isinstance(shots, dict) else None
             per_circuit.append(self._fetch_raw_shots(url, ctx=f"child {child_id}"))
         return per_circuit
-
-    @staticmethod
-    def _find_shots_v2_id(results: dict) -> str | None:
-        """Artifact id of the v2 per-register shots, or ``None``."""
-        for value in results.values():
-            if isinstance(value, dict) and str(value.get("format", "")).endswith(
-                "shots.json.v2"
-            ):
-                return value.get("id")
-        return None
 
     def _fetch_qasm3_shots(self, extra_query_params: dict | None = None) -> list:
         """Fetch the per-register shots array for a qasm3 (MCM) job."""

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -725,9 +725,7 @@ class IonQJob(JobV1):
             self._shots_artifact_id,
             extra_query_params=extra_query_params,
         )
-        if isinstance(payload, dict) and "shots" in payload:
-            return payload["shots"]
-        return payload
+        return payload.get("shots", [])  # artifact is {"shots": [...]}
 
     def _format_result_qasm3(self, shots: list):
         """Translate per-register shot-wise (qasm3/MCM) results into a Result.
@@ -742,9 +740,6 @@ class IonQJob(JobV1):
         success = self._status == jobstatus.JobStatus.DONE
         metadata = self._metadata.get("metadata") or {}
         decoded = decompress_metadata_string(metadata.get("qiskit_header"))
-        # Single-circuit, so the header is a lone dict; tolerate a list.
-        if isinstance(decoded, list):
-            decoded = decoded[0] if decoded else {}
         header = decoded if isinstance(decoded, dict) else {}
 
         shots = shots or []

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -207,8 +207,7 @@ class IonQJob(JobV1):
         self._execution_time = None
         self._dry_run: bool = False
         self._results_urls: dict[str, str | None] = {}
-        # ionq.qasm3.v1 (mid-circuit measurement) jobs return per-register
-        # shots from a separate artifact; set in status() from the job type.
+        # Set in status() for ionq.qasm3.v1 (mid-circuit measurement) jobs.
         self._is_qasm3: bool = False
         self._shots_artifact_id: str | None = None
         self._metadata: dict[str, Any] = {}
@@ -256,13 +255,8 @@ class IonQJob(JobV1):
 
     @staticmethod
     def _resolve_compiled_format(lang: str, available: dict) -> str | None:
-        """Map a ``lang`` hint to an available compiled-circuit format key.
-
-        Accepts an exact format key, or a short representation name matched
-        against the ``ionq.<name>.vN`` format (``"native"`` ->
-        ``"ionq.native.v1"``). Only the representation segment is matched, so
-        generic tokens like ``"ionq"`` or ``"v1"`` don't resolve. Only keys
-        whose artifact carries an ``id`` are considered.
+        """Map ``lang`` (exact key or short name like ``"native"``) to an
+        available format key with an artifact ``id``, else ``None``.
         """
 
         def has_id(key: str) -> bool:
@@ -277,36 +271,13 @@ class IonQJob(JobV1):
         )
 
     def compiled_circuit(self, lang: str = "native") -> dict | list | str:
-        """Fetch the server-compiled circuit for this job.
+        """Fetch the server-compiled circuit, parsed from its published artifact.
 
-        Useful for jobs submitted with ``dry_run=True`` (compilation as a
-        service) but also works for any completed job to inspect what was
-        actually run on hardware after IonQ's compiler resynthesizes the input.
-        The IonQ Cloud publishes each compiled representation as an artifact
-        under ``output.compilation.compiled_circuits``; this resolves the one
-        matching ``lang`` and fetches it from the artifacts endpoint.
-
-        Args:
-            lang (str): Which compiled representation to fetch. Accepts a short
-                name matched against the available format keys (e.g.
-                ``"native"`` -> ``"ionq.native.v1"``, ``"qasm3"`` ->
-                ``"ionq.qasm3.v1"``) or an exact format key. The set of
-                available formats varies by job and compiler.
-
-        Raises:
-            IonQJobStateError: If the job has not reached a final state yet.
-            IonQJobFailureError: If the job failed before compilation completed.
-            IonQJobError: If the job publishes no compiled circuit matching
-                ``lang`` (the message lists the formats it does publish).
-            IonQAPIError: If the artifact fetch is rejected (e.g. per-org
-                entitlement).
-
-        Returns:
-            The compiled circuit parsed from its JSON artifact: a ``dict`` for
-            native/IR JSON formats, a ``str`` for text formats (OpenQASM).
+        ``lang`` is a short name (``"native"``) or exact format key matched
+        against ``output.compilation.compiled_circuits``; raises
+        ``IonQJobError`` if none match. Returns a ``dict`` (native/IR JSON) or
+        ``str`` (OpenQASM).
         """
-        # Make sure we're in a final state and the job-id is known. status()
-        # raises IonQJobFailureError on failure, which is the right behavior.
         self.status()
         if self._status not in jobstatus.JOB_FINAL_STATES:
             raise exceptions.IonQJobStateError(
@@ -526,8 +497,7 @@ class IonQJob(JobV1):
 
             self._num_qubits = self._first_of(stats, "qubits", default=0)
 
-            # Mid-circuit measurement jobs come back as ionq.qasm3.v1 and
-            # carry per-register shot-wise results in a dedicated artifact.
+            # qasm3 jobs carry per-register results in a separate artifact.
             self._is_qasm3 = response.get("type") == "ionq.qasm3.v1"
 
             # Dry-run jobs have results=null; non-dry-run may also be null mid-rollout.
@@ -696,11 +666,7 @@ class IonQJob(JobV1):
 
     @staticmethod
     def _find_shots_v2_id(results: dict) -> str | None:
-        """Return the ``ionq.result.shots.json.v2`` artifact id, if advertised.
-
-        The per-register shot-wise format is keyed by an artifact ``id``
-        (fetched via ``/jobs/{id}/artifacts/{aid}``) rather than a ``url``.
-        """
+        """Artifact id of the v2 per-register shots, or ``None``."""
         for value in results.values():
             if isinstance(value, dict) and str(value.get("format", "")).endswith(
                 "shots.json.v2"
@@ -709,11 +675,7 @@ class IonQJob(JobV1):
         return None
 
     def _fetch_qasm3_shots(self, extra_query_params: dict | None = None) -> list:
-        """Fetch the per-register shots array for a qasm3 (MCM) job.
-
-        Raises:
-            IonQJobError: If the job advertised no v2 shots artifact.
-        """
+        """Fetch the per-register shots array for a qasm3 (MCM) job."""
         if not self._shots_artifact_id:
             raise exceptions.IonQJobError(
                 f"Job {self._job_id} reported no per-register shots artifact; "
@@ -728,13 +690,9 @@ class IonQJob(JobV1):
         return payload.get("shots", [])  # artifact is {"shots": [...]}
 
     def _format_result_qasm3(self, shots: list):
-        """Translate per-register shot-wise (qasm3/MCM) results into a Result.
-
-        Each shot is ``{"registers": {name: [bit, ...], ...}}``. The user's
-        declared registers are folded into one integer per shot via the
-        header's ``clbit_labels``, so ``get_counts()``/``get_memory()`` split
-        across registers as usual. The system-appended ``output_all`` register
-        is excluded.
+        """Build a Result from per-register shots, folding the declared
+        registers via the header's ``clbit_labels``. ``output_all``
+        (system-added) is excluded.
         """
         backend = self.backend()
         success = self._status == jobstatus.JobStatus.DONE
@@ -744,8 +702,7 @@ class IonQJob(JobV1):
 
         shots = shots or []
         clbit_labels = header.get("clbit_labels") or []
-        # Zero-padded MSB-left binary (as the v1 path) so Result.get_counts()
-        # splits across registers via the header's creg_sizes.
+        # Zero-padded binary so get_counts() splits by creg_sizes.
         width = header.get("memory_slots") or len(clbit_labels)
 
         counts: dict[str, int] = {}

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -258,9 +258,11 @@ class IonQJob(JobV1):
     def _resolve_compiled_format(lang: str, available: dict) -> str | None:
         """Map a ``lang`` hint to an available compiled-circuit format key.
 
-        Accepts an exact format key, or a short name matched against the
-        dotted format (``"native"`` -> ``"ionq.native.v1"``). Only keys whose
-        artifact carries an ``id`` are considered.
+        Accepts an exact format key, or a short representation name matched
+        against the ``ionq.<name>.vN`` format (``"native"`` ->
+        ``"ionq.native.v1"``). Only the representation segment is matched, so
+        generic tokens like ``"ionq"`` or ``"v1"`` don't resolve. Only keys
+        whose artifact carries an ``id`` are considered.
         """
 
         def has_id(key: str) -> bool:
@@ -269,9 +271,12 @@ class IonQJob(JobV1):
 
         if has_id(lang):
             return lang
-        return next((k for k in available if lang in k.split(".") and has_id(k)), None)
+        return next(
+            (k for k in available if has_id(k) and k.split(".")[1:2] == [lang]),
+            None,
+        )
 
-    def compiled_circuit(self, lang: str = "native"):
+    def compiled_circuit(self, lang: str = "native") -> dict | list | str:
         """Fetch the server-compiled circuit for this job.
 
         Useful for jobs submitted with ``dry_run=True`` (compilation as a

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -254,28 +254,51 @@ class IonQJob(JobV1):
         """
         return self._dry_run
 
-    def compiled_circuit(self, lang: str = "native") -> str:
+    @staticmethod
+    def _resolve_compiled_format(lang: str, available: dict) -> str | None:
+        """Map a ``lang`` hint to an available compiled-circuit format key.
+
+        Accepts an exact format key, or a short name matched against the
+        dotted format (``"native"`` -> ``"ionq.native.v1"``). Only keys whose
+        artifact carries an ``id`` are considered.
+        """
+
+        def has_id(key: str) -> bool:
+            entry = available.get(key)
+            return isinstance(entry, dict) and bool(entry.get("id"))
+
+        if has_id(lang):
+            return lang
+        return next((k for k in available if lang in k.split(".") and has_id(k)), None)
+
+    def compiled_circuit(self, lang: str = "native"):
         """Fetch the server-compiled circuit for this job.
 
         Useful for jobs submitted with ``dry_run=True`` (compilation as a
         service) but also works for any completed job to inspect what was
         actually run on hardware after IonQ's compiler resynthesizes the input.
+        The IonQ Cloud publishes each compiled representation as an artifact
+        under ``output.compilation.compiled_circuits``; this resolves the one
+        matching ``lang`` and fetches it from the artifacts endpoint.
 
         Args:
-            lang (str): Output language. ``"native"`` (default) returns the
-                IonQ-native gate JSON; ``"qasm3"`` returns OpenQASM 3 source.
-                Other values may be accepted depending on organization
-                entitlement; the API rejects unsupported or non-entitled
-                values with a ``4xx`` response surfaced here as
-                :class:`~qiskit_ionq.exceptions.IonQAPIError`.
+            lang (str): Which compiled representation to fetch. Accepts a short
+                name matched against the available format keys (e.g.
+                ``"native"`` -> ``"ionq.native.v1"``, ``"qasm3"`` ->
+                ``"ionq.qasm3.v1"``) or an exact format key. The set of
+                available formats varies by job and compiler.
 
         Raises:
             IonQJobStateError: If the job has not reached a final state yet.
             IonQJobFailureError: If the job failed before compilation completed.
-            IonQAPIError: If the API rejects the ``lang`` value.
+            IonQJobError: If the job publishes no compiled circuit matching
+                ``lang`` (the message lists the formats it does publish).
+            IonQAPIError: If the artifact fetch is rejected (e.g. per-org
+                entitlement).
 
         Returns:
-            str: The compiled circuit as a string (IonQ-native JSON or OpenQASM 3).
+            The compiled circuit parsed from its JSON artifact: a ``dict`` for
+            native/IR JSON formats, a ``str`` for text formats (OpenQASM).
         """
         # Make sure we're in a final state and the job-id is known. status()
         # raises IonQJobFailureError on failure, which is the right behavior.
@@ -286,7 +309,17 @@ class IonQJob(JobV1):
                 "Call wait_for_final_state() first."
             )
         assert self._job_id is not None
-        return self._client.get_compiled_circuit(self._job_id, lang=lang)
+        circuits = ((self._metadata.get("output") or {}).get("compilation") or {}).get(
+            "compiled_circuits"
+        ) or {}
+        fmt = self._resolve_compiled_format(lang, circuits)
+        if fmt is None:
+            available = ", ".join(sorted(circuits)) or "none"
+            raise exceptions.IonQJobError(
+                f"No compiled circuit matching {lang!r} for job {self._job_id}. "
+                f"Available formats: {available}."
+            )
+        return self._client.get_artifact(self._job_id, circuits[fmt]["id"])
 
     def cancel(self) -> None:
         """Cancel this job."""

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, patch
-VERSION_INFO = ".".join(map(str, (1, 0, 3)))
+VERSION_INFO = ".".join(map(str, (1, 1, 0)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -522,8 +522,7 @@ def test_qasm3_payload_shape(qpu_backend):
     assert payload["input"]["qubits"] == 1
     data = payload["input"]["data"]
     assert data.startswith("OPENQASM 3.0;")
-    # Behavior we own: the MCM is present and both registers are declared.
-    # Avoid asserting qiskit's exact assignment spelling (varies by version).
+    # Don't assert qiskit's exact qasm3 spelling; just the structure.
     assert "measure" in data and "mid" in data and "result" in data
     header = decompress_metadata_string(payload["metadata"]["qiskit_header"])
     assert header["creg_sizes"] == [["mid", 1], ["result", 2]]

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -520,8 +520,11 @@ def test_qasm3_payload_shape(qpu_backend):
     payload = json.loads(ionq_json)
     assert payload["type"] == "ionq.qasm3.v1"
     assert payload["input"]["qubits"] == 1
-    assert payload["input"]["data"].startswith("OPENQASM 3.0;")
-    assert "mid[0] = measure q[0];" in payload["input"]["data"]
+    data = payload["input"]["data"]
+    assert data.startswith("OPENQASM 3.0;")
+    # Behavior we own: the MCM is present and both registers are declared.
+    # Avoid asserting qiskit's exact assignment spelling (varies by version).
+    assert "measure" in data and "mid" in data and "result" in data
     header = decompress_metadata_string(payload["metadata"]["qiskit_header"])
     assert header["creg_sizes"] == [["mid", 1], ["result", 2]]
     assert header["memory_slots"] == 3
@@ -560,3 +563,45 @@ def test_qasm3_simulator_noise(simulator_backend):
     assert payload["type"] == "ionq.qasm3.v1"
     assert payload["backend"] == "simulator"
     assert payload["noise"]["model"] == "ideal"
+
+
+def test_qasm3_reset_payload(qpu_backend):
+    """A mid-circuit reset routes to qasm3 and the reset survives export."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.reset(0)
+    qc.measure(0, 0)
+    payload = json.loads(qiskit_to_ionq(qc, qpu_backend, passed_args={"shots": 10}))
+    assert payload["type"] == "ionq.qasm3.v1"
+    assert "reset" in payload["input"]["data"]
+
+
+def test_qasm3_reserved_creg(qpu_backend):
+    """A creg name that qasm3 renames (reserved word) is rejected, not silent."""
+    qr = QuantumRegister(1, "q")
+    mid = ClassicalRegister(1, "mid")
+    out = ClassicalRegister(1, "output")  # 'output' is renamed to 'output_0'
+    qc = QuantumCircuit(qr, mid, out)
+    qc.h(0)
+    qc.measure(0, mid[0])
+    qc.x(0)
+    qc.measure(0, out[0])
+    with pytest.raises(IonQJobError, match="reserved words"):
+        qiskit_to_ionq(qc, qpu_backend, passed_args={"shots": 10})
+
+
+def test_v1_settings_merge(simulator_backend):
+    """v1 path merges the ErrorMitigation enum into job_settings.error_mitigation."""
+    args = {
+        "shots": 10,
+        "job_settings": {"error_mitigation": {"symmetry_verification": True}},
+        "error_mitigation": ErrorMitigation.NO_DEBIASING,
+    }
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    payload = json.loads(qiskit_to_ionq(qc, simulator_backend, passed_args=args))
+    assert payload["settings"]["error_mitigation"] == {
+        "symmetry_verification": True,
+        "debiasing": False,
+    }

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -514,6 +514,27 @@ def test_requires_qasm3_plain():
     assert circuit_requires_qasm3(qc) is False
 
 
+def test_requires_qasm3_if_else():
+    """An if/else block (both branches) requires the qasm3 path."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    with qc.if_test((qc.cregs[0], 1)) as else_:
+        qc.x(0)
+    with else_:
+        qc.z(0)
+    assert circuit_requires_qasm3(qc) is True
+
+
+def test_requires_qasm3_reuse():
+    """A gate after a measurement (qubit reuse) requires the qasm3 path."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    qc.x(0)
+    assert circuit_requires_qasm3(qc) is True
+
+
 def test_qasm3_payload_shape(qpu_backend):
     """MCM circuits serialize to an ionq.qasm3.v1 payload with QASM 3 input."""
     ionq_json = qiskit_to_ionq(_mcm_circuit(), qpu_backend, passed_args={"shots": 10})
@@ -524,6 +545,10 @@ def test_qasm3_payload_shape(qpu_backend):
     assert data.startswith("OPENQASM 3.0;")
     # Don't assert qiskit's exact qasm3 spelling; just the structure.
     assert "measure" in data and "mid" in data and "result" in data
+    # Exactly the gates we built (1 H, 2 X, 3 measure) and nothing injected.
+    assert data.count("measure") == 3
+    assert data.count("h q") == 1
+    assert data.count("x q") == 2
     header = decompress_metadata_string(payload["metadata"]["qiskit_header"])
     assert header["creg_sizes"] == [["mid", 1], ["result", 2]]
     assert header["memory_slots"] == 3

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -34,9 +34,10 @@ from qiskit.compiler import transpile
 from qiskit.result import marginal_counts
 from qiskit.transpiler.exceptions import TranspilerError
 
-from qiskit_ionq.exceptions import IonQGateError
+from qiskit_ionq.exceptions import IonQGateError, IonQJobError
 from qiskit_ionq.helpers import (
     qiskit_to_ionq,
+    circuit_requires_qasm3,
     decompress_metadata_string,
     compress_to_metadata_string,
     get_user_agent,
@@ -463,3 +464,99 @@ def test_counts_marginalize(simulator_backend, requests_mock):
     ]
     assert counts_full == {"0000": shots}
     assert marginal_counts(counts_full, indices=measured) == {"00": shots}
+
+
+def _mcm_circuit():
+    """1-qubit mid-circuit-measurement circuit (the API schema example)."""
+    qr = QuantumRegister(1, "q")
+    mid = ClassicalRegister(1, "mid")
+    result = ClassicalRegister(2, "result")
+    qc = QuantumCircuit(qr, mid, result, name="mcm")
+    qc.h(0)
+    qc.measure(0, mid[0])
+    qc.x(0)
+    qc.measure(0, result[0])
+    qc.x(0)
+    qc.measure(0, result[1])
+    return qc
+
+
+def test_requires_qasm3_mcm():
+    """Reusing a qubit after measurement requires the qasm3 path."""
+    assert circuit_requires_qasm3(_mcm_circuit()) is True
+
+
+def test_requires_qasm3_reset():
+    """A mid-circuit reset requires the qasm3 path."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.reset(0)
+    qc.measure(0, 0)
+    assert circuit_requires_qasm3(qc) is True
+
+
+def test_requires_qasm3_ctrl_flow():
+    """Classical control flow requires the qasm3 path."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    with qc.if_test((qc.cregs[0], 1)):
+        qc.x(0)
+    assert circuit_requires_qasm3(qc) is True
+
+
+def test_requires_qasm3_plain():
+    """A plain terminal-measurement circuit stays on the v1 path."""
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure([0, 1], [0, 1])
+    assert circuit_requires_qasm3(qc) is False
+
+
+def test_qasm3_payload_shape(qpu_backend):
+    """MCM circuits serialize to an ionq.qasm3.v1 payload with QASM 3 input."""
+    ionq_json = qiskit_to_ionq(_mcm_circuit(), qpu_backend, passed_args={"shots": 10})
+    payload = json.loads(ionq_json)
+    assert payload["type"] == "ionq.qasm3.v1"
+    assert payload["input"]["qubits"] == 1
+    assert payload["input"]["data"].startswith("OPENQASM 3.0;")
+    assert "mid[0] = measure q[0];" in payload["input"]["data"]
+    header = decompress_metadata_string(payload["metadata"]["qiskit_header"])
+    assert header["creg_sizes"] == [["mid", 1], ["result", 2]]
+    assert header["memory_slots"] == 3
+
+
+def test_qasm3_settings_passthrough(qpu_backend):
+    """job_settings and error_mitigation flow through on the qasm3 path."""
+    args = {
+        "shots": 10,
+        "job_settings": {
+            "include_leakage": False,
+            "error_mitigation": {"symmetry_verification": True},
+        },
+        "error_mitigation": ErrorMitigation.NO_DEBIASING,
+    }
+    payload = json.loads(qiskit_to_ionq(_mcm_circuit(), qpu_backend, passed_args=args))
+    assert payload["settings"]["include_leakage"] is False
+    assert payload["settings"]["error_mitigation"] == {
+        "symmetry_verification": True,
+        "debiasing": False,
+    }
+
+
+def test_multi_circuit_mcm_raises(qpu_backend):
+    """Multi-circuit MCM submissions are rejected with a clear error."""
+    circuits = [_mcm_circuit(), _mcm_circuit()]
+    with pytest.raises(IonQJobError, match="single-circuit"):
+        qiskit_to_ionq(circuits, qpu_backend, passed_args={"shots": 10})
+
+
+def test_qasm3_simulator_noise(simulator_backend):
+    """MCM on the simulator carries the noise block, like the v1 path."""
+    payload = json.loads(
+        qiskit_to_ionq(_mcm_circuit(), simulator_backend, passed_args={"shots": 10})
+    )
+    assert payload["type"] == "ionq.qasm3.v1"
+    assert payload["backend"] == "simulator"
+    assert payload["noise"]["model"] == "ideal"

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1263,7 +1263,7 @@ def test_compiled_unknown_format(mock_backend, requests_mock):
         job.compiled_circuit(lang="mir")
 
 
-def test_compiled_artifact_api_error(mock_backend, requests_mock):
+def test_compiled_artifact_error(mock_backend, requests_mock):
     """A non-2xx on the artifact fetch (e.g. entitlement) surfaces as IonQAPIError."""
     job_id = "dry_run_id"
     requests_mock.get(
@@ -1421,3 +1421,72 @@ def test_qasm3_no_shots_artifact(mock_backend, requests_mock):
     job = mock_backend.run(_mcm_circuit(), shots=4)
     with pytest.raises(exceptions.IonQJobError, match="shots artifact"):
         job.result()
+
+
+def test_qasm3_high_bit(mock_backend, requests_mock):
+    """A set high-order register bit (result[1]) folds to the MSB position."""
+    job_id = "mcm_hi"
+    artifact_id = "shots-hi"
+    client = mock_backend.client
+    requests_mock.post(client.make_path("jobs"), json={"id": job_id})
+    requests_mock.get(
+        client.make_path("jobs", job_id),
+        json=_qasm3_job_response(job_id, artifact_id),
+    )
+    # result[1] is clbit index 2 -> MSB of the 3-bit word; expect "10 0".
+    requests_mock.get(
+        client.make_path("jobs", job_id, "artifacts", artifact_id),
+        json={"shots": [{"registers": {"mid": [0], "result": [0, 1]}}]},
+    )
+
+    job = mock_backend.run(_mcm_circuit(), shots=1)
+    assert job.result().get_counts() == {"10 0": 1}
+
+
+def test_qasm3_memory_false(mock_backend, requests_mock):
+    """Without memory=True, MCM counts still decode but get_memory() raises."""
+    job_id = "mcm_nomem"
+    artifact_id = "shots-nomem"
+    client = mock_backend.client
+    requests_mock.post(client.make_path("jobs"), json={"id": job_id})
+    requests_mock.get(
+        client.make_path("jobs", job_id),
+        json=_qasm3_job_response(job_id, artifact_id),
+    )
+    requests_mock.get(
+        client.make_path("jobs", job_id, "artifacts", artifact_id),
+        json=_QASM3_SHOTS,
+    )
+
+    job = mock_backend.run(_mcm_circuit(), shots=4)  # memory defaults to False
+    res = job.result()
+    assert res.get_counts() == {"00 0": 3, "01 1": 1}
+    assert res.data(0).get("memory") is None
+    with pytest.raises(exceptions.IonQBackendError, match="memory=True"):
+        job.get_memory()
+
+
+def test_compiled_no_output(mock_backend, requests_mock):
+    """A job with no published compiled_circuits raises a clear IonQJobError."""
+    job_id = "dry_run_id"
+    response = _dry_run_job_response(job_id)
+    response["output"] = None  # prod mid-rollout: endpoint 410'd, artifacts absent
+    requests_mock.get(mock_backend.client.make_path("jobs", job_id), json=response)
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    with pytest.raises(exceptions.IonQJobError, match="Available formats: none"):
+        job.compiled_circuit()
+
+
+def test_compiled_format_no_id(mock_backend, requests_mock):
+    """A published format whose artifact lacks an id is treated as unavailable."""
+    job_id = "dry_run_id"
+    response = _dry_run_job_response(job_id)
+    response["output"]["compilation"]["compiled_circuits"] = {
+        "ionq.native.v1": {"format": "ionq.native.v1", "media_type": "application/json"}
+    }
+    requests_mock.get(mock_backend.client.make_path("jobs", job_id), json=response)
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    with pytest.raises(exceptions.IonQJobError, match="Available formats"):
+        job.compiled_circuit(lang="native")

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1141,8 +1141,7 @@ def _dry_run_job_response(job_id, target="qpu.forte-1"):
         "shots": 1024,
         "metadata": {"qiskit_header": qiskit_header, "shots": "1024"},
         "stats": {"qubits": 2, "circuits": 1},
-        # Compiled circuits are published as artifacts keyed by format under
-        # output.compilation.compiled_circuits; fetched via /artifacts/{id}.
+        # Compiled circuits: artifacts keyed by format, fetched via /artifacts/{id}.
         "output": {
             "compilation": {
                 "opt": 1,
@@ -1390,8 +1389,7 @@ def _qasm3_job_response(job_id, shots_artifact_id):
     }
 
 
-# Per-register shot-wise artifact (ionq.result.shots.json.v2): 3 shots of
-# mid=0/result=00 and 1 shot of mid=1/result=10. output_all is system-appended.
+# v2 shots artifact: 3x mid=0/result=00, 1x mid=1/result=10.
 _QASM3_SHOTS = {
     "shots": [
         {"registers": {"mid": [0], "result": [0, 0], "output_all": [1]}},

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1141,6 +1141,28 @@ def _dry_run_job_response(job_id, target="qpu.forte-1"):
         "shots": 1024,
         "metadata": {"qiskit_header": qiskit_header, "shots": "1024"},
         "stats": {"qubits": 2, "circuits": 1},
+        # Compiled circuits are published as artifacts keyed by format under
+        # output.compilation.compiled_circuits; fetched via /artifacts/{id}.
+        "output": {
+            "compilation": {
+                "opt": 1,
+                "precision": "1E-3",
+                "gate_basis": "ZZ",
+                "service_version": "v0.4",
+                "compiled_circuits": {
+                    "ionq.native.v1": {
+                        "id": "native-aid",
+                        "format": "ionq.native.v1",
+                        "media_type": "application/json",
+                    },
+                    "ionq.qasm3.v1": {
+                        "id": "qasm3-aid",
+                        "format": "ionq.qasm3.v1",
+                        "media_type": "application/json",
+                    },
+                },
+            }
+        },
         # Per v0.4 spec, dry-run jobs have results=null.
         "results": None,
     }
@@ -1191,29 +1213,28 @@ def test_dry_run_result_raises(mock_backend, requests_mock):
 
 
 def test_dry_run_compiled_native(mock_backend, requests_mock):
-    """compiled_circuit(lang='native') hits /jobs/<id>/circuits/native and
-    returns the JSON-decoded body as a string."""
+    """compiled_circuit('native') resolves ionq.native.v1 and fetches the artifact."""
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
         json=_dry_run_job_response(job_id),
     )
 
-    native_body = (
-        '{"gateset":"native","circuit":[{"gate":"gpi2","target":0,"phase":0.0}]}'
-    )
+    native = {"gateset": "native", "circuit": [{"gate": "gpi2", "target": 0}]}
     requests_mock.get(
-        mock_backend.client.make_path("jobs", job_id, "circuits", "native"),
-        json=native_body,
+        mock_backend.client.make_path("jobs", job_id, "artifacts", "native-aid"),
+        json=native,
     )
 
     job = ionq_job.IonQJob(mock_backend, job_id)
-    assert job.compiled_circuit() == native_body
-    assert job.compiled_circuit(lang="native") == native_body
+    assert job.compiled_circuit() == native
+    assert job.compiled_circuit(lang="native") == native
+    # An exact format key resolves too.
+    assert job.compiled_circuit(lang="ionq.native.v1") == native
 
 
 def test_dry_run_compiled_qasm3(mock_backend, requests_mock):
-    """compiled_circuit(lang='qasm3') returns the OpenQASM 3 string."""
+    """compiled_circuit('qasm3') returns the OpenQASM 3 string from its artifact."""
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
@@ -1222,7 +1243,7 @@ def test_dry_run_compiled_qasm3(mock_backend, requests_mock):
 
     qasm3 = "OPENQASM 3.0;\ngate gpi2(p) q { } // ...\n"
     requests_mock.get(
-        mock_backend.client.make_path("jobs", job_id, "circuits", "qasm3"),
+        mock_backend.client.make_path("jobs", job_id, "artifacts", "qasm3-aid"),
         json=qasm3,
     )
 
@@ -1230,47 +1251,37 @@ def test_dry_run_compiled_qasm3(mock_backend, requests_mock):
     assert job.compiled_circuit(lang="qasm3") == qasm3
 
 
-def test_compiled_lang_passthrough(mock_backend, requests_mock):
-    """Any string is forwarded to the API as-is.
-
-    The server is the source of truth for which lang values are accepted
-    and which are gated behind per-organization entitlement; the SDK does
-    not duplicate that policy. This test mocks the request URL with a
-    non-default lang and confirms it is reached.
-    """
+def test_compiled_unknown_format(mock_backend, requests_mock):
+    """A lang with no matching artifact raises, listing what is available."""
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
         json=_dry_run_job_response(job_id),
-    )
-    requests_mock.get(
-        mock_backend.client.make_path("jobs", job_id, "circuits", "future-lang"),
-        json="some-payload",
     )
     job = ionq_job.IonQJob(mock_backend, job_id)
-    assert job.compiled_circuit(lang="future-lang") == "some-payload"
+    with pytest.raises(exceptions.IonQJobError, match="Available formats"):
+        job.compiled_circuit(lang="mir")
 
 
-def test_compiled_lang_api_error(mock_backend, requests_mock):
-    """Server-side rejection of an unsupported / non-entitled lang surfaces
-    as IonQAPIError, matching every other non-2xx API response."""
+def test_compiled_artifact_api_error(mock_backend, requests_mock):
+    """A non-2xx on the artifact fetch (e.g. entitlement) surfaces as IonQAPIError."""
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
         json=_dry_run_job_response(job_id),
     )
     requests_mock.get(
-        mock_backend.client.make_path("jobs", job_id, "circuits", "nope"),
+        mock_backend.client.make_path("jobs", job_id, "artifacts", "native-aid"),
         status_code=403,
         json={
             "statusCode": 403,
             "error": "Forbidden",
-            "message": "Organization does not have access to this compiled language",
+            "message": "Organization does not have access to this artifact",
         },
     )
     job = ionq_job.IonQJob(mock_backend, job_id)
     with pytest.raises(exceptions.IonQAPIError):
-        job.compiled_circuit(lang="nope")
+        job.compiled_circuit(lang="native")
 
 
 def test_dry_run_property_false(mock_backend, requests_mock):

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1154,9 +1154,9 @@ def _dry_run_job_response(job_id, target="qpu.forte-1"):
                         "format": "ionq.native.v1",
                         "media_type": "application/json",
                     },
-                    "ionq.qasm3.v1": {
-                        "id": "qasm3-aid",
-                        "format": "ionq.qasm3.v1",
+                    "ionq.ore.v1": {
+                        "id": "ore-aid",
+                        "format": "ionq.ore.v1",
                         "media_type": "application/json",
                     },
                 },
@@ -1232,22 +1232,53 @@ def test_dry_run_compiled_native(mock_backend, requests_mock):
     assert job.compiled_circuit(lang="ionq.native.v1") == native
 
 
-def test_dry_run_compiled_qasm3(mock_backend, requests_mock):
-    """compiled_circuit('qasm3') returns the OpenQASM 3 string from its artifact."""
+def test_dry_run_compiled_ore(mock_backend, requests_mock):
+    """compiled_circuit('ore') resolves ionq.ore.v1 and fetches the artifact."""
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
         json=_dry_run_job_response(job_id),
     )
 
-    qasm3 = "OPENQASM 3.0;\ngate gpi2(p) q { } // ...\n"
+    ore = {"format": "ore", "circuit": [{"op": "rz", "target": 0, "angle": 0.5}]}
     requests_mock.get(
-        mock_backend.client.make_path("jobs", job_id, "artifacts", "qasm3-aid"),
-        json=qasm3,
+        mock_backend.client.make_path("jobs", job_id, "artifacts", "ore-aid"),
+        json=ore,
     )
 
     job = ionq_job.IonQJob(mock_backend, job_id)
-    assert job.compiled_circuit(lang="qasm3") == qasm3
+    assert job.compiled_circuit(lang="ore") == ore
+    assert job.compiled_circuit(lang="ionq.ore.v1") == ore
+
+
+def test_compiled_mir_bytes(mock_backend, requests_mock):
+    """A qasm3 job's ionq.mir.v1 (octet-stream) returns raw bytes, not JSON."""
+    job_id = "mcm_mir"
+    response = _qasm3_job_response(job_id, "unused")
+    response["output"] = {
+        "compilation": {
+            "compiled_circuits": {
+                "ionq.mir.v1": {
+                    "id": "mir-aid",
+                    "format": "ionq.mir.v1",
+                    "media_type": "application/octet-stream",
+                }
+            }
+        }
+    }
+    client = mock_backend.client
+    requests_mock.get(client.make_path("jobs", job_id), json=response)
+    blob = b"\x00\x01MIR\xff"
+    requests_mock.get(
+        client.make_path("jobs", job_id, "artifacts", "mir-aid"),
+        content=blob,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+
+    job = ionq_job.IonQJob(mock_backend, job_id)
+    assert job.compiled_circuit(lang="mir") == blob
+    with pytest.raises(exceptions.IonQJobError, match="Available formats"):
+        job.compiled_circuit()
 
 
 def _strip_native_id(response):

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -30,7 +30,7 @@ from unittest import mock
 import warnings
 
 import pytest
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.providers import exceptions as q_exc
 from qiskit.providers import jobstatus
 from qiskit.result import MeasLevel
@@ -1312,3 +1312,101 @@ def test_multi_null_meta_result(mock_backend, requests_mock):
     assert result.get_counts(0) == {"00": 512, "11": 512}
     # X: max key 1 -> 1 qubit inferred -> 1-char bitstrings.
     assert result.get_counts(1) == {"1": 1024}
+
+
+def _mcm_circuit():
+    """1-qubit mid-circuit-measurement circuit (the API schema example)."""
+    qr = QuantumRegister(1, "q")
+    mid = ClassicalRegister(1, "mid")
+    result = ClassicalRegister(2, "result")
+    qc = QuantumCircuit(qr, mid, result, name="mcm")
+    qc.h(0)
+    qc.measure(0, mid[0])
+    qc.x(0)
+    qc.measure(0, result[0])
+    qc.x(0)
+    qc.measure(0, result[1])
+    return qc
+
+
+def _qasm3_job_response(job_id, shots_artifact_id):
+    """Completed ionq.qasm3.v1 response: v1 result URLs + a v2 shots artifact id."""
+    header = compress_to_metadata_string(
+        {
+            "memory_slots": 3,
+            "creg_sizes": [["mid", 1], ["result", 2]],
+            "clbit_labels": [["mid", 0], ["result", 0], ["result", 1]],
+            "qreg_sizes": [["q", 1]],
+            "qubit_labels": [["q", 0]],
+            "n_qubits": 1,
+            "name": "mcm",
+            "global_phase": 0,
+        }
+    )
+    return {
+        "id": job_id,
+        "type": "ionq.qasm3.v1",
+        "status": "completed",
+        "stats": {"qubits": 1, "circuits": 1},
+        "metadata": {"qiskit_header": header, "shots": "4"},
+        "results": {
+            "shots": {"url": f"/v0.4/jobs/{job_id}/results/shots"},
+            "histogram": {"url": f"/v0.4/jobs/{job_id}/results/histogram"},
+            "probabilities": {"url": f"/v0.4/jobs/{job_id}/results/probabilities"},
+            "ionq.result.shots.json.v2": {
+                "id": shots_artifact_id,
+                "format": "ionq.result.shots.json.v2",
+                "media_type": "application/json",
+            },
+        },
+        "execution_duration_ms": 0,
+    }
+
+
+# Per-register shot-wise artifact (ionq.result.shots.json.v2): 3 shots of
+# mid=0/result=00 and 1 shot of mid=1/result=10. output_all is system-appended.
+_QASM3_SHOTS = {
+    "shots": [
+        {"registers": {"mid": [0], "result": [0, 0], "output_all": [1]}},
+        {"registers": {"mid": [0], "result": [0, 0], "output_all": [0]}},
+        {"registers": {"mid": [0], "result": [0, 0], "output_all": [1]}},
+        {"registers": {"mid": [1], "result": [1, 0], "output_all": [0]}},
+    ]
+}
+
+
+def test_qasm3_result_counts(mock_backend, requests_mock):
+    """MCM jobs fold per-register shots into register-split counts + memory."""
+    job_id = "mcm_job"
+    artifact_id = "shots-v2-uuid"
+    client = mock_backend.client
+    requests_mock.post(client.make_path("jobs"), json={"id": job_id})
+    requests_mock.get(
+        client.make_path("jobs", job_id),
+        json=_qasm3_job_response(job_id, artifact_id),
+    )
+    requests_mock.get(
+        client.make_path("jobs", job_id, "artifacts", artifact_id),
+        json=_QASM3_SHOTS,
+    )
+
+    job = mock_backend.run(_mcm_circuit(), shots=4, memory=True)
+    res = job.result()
+
+    # Qiskit splits as "result mid": mid=1,result=10 -> "01 1".
+    assert res.get_counts() == {"00 0": 3, "01 1": 1}
+    assert res.get_memory() == ["00 0", "00 0", "00 0", "01 1"]
+
+
+def test_qasm3_no_shots_artifact(mock_backend, requests_mock):
+    """A qasm3 job missing its v2 shots artifact raises a clear error."""
+    job_id = "mcm_job_2"
+    response = _qasm3_job_response(job_id, "unused")
+    response["results"].pop("ionq.result.shots.json.v2")
+    client = mock_backend.client
+    requests_mock.post(client.make_path("jobs"), json={"id": job_id})
+    requests_mock.get(client.make_path("jobs", job_id), json=response)
+
+    job = mock_backend.run(_mcm_circuit(), shots=4)
+    with pytest.raises(exceptions.IonQJobError, match="shots artifact"):
+        job.result()

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1251,16 +1251,32 @@ def test_dry_run_compiled_qasm3(mock_backend, requests_mock):
     assert job.compiled_circuit(lang="qasm3") == qasm3
 
 
-def test_compiled_unknown_format(mock_backend, requests_mock):
-    """A lang with no matching artifact raises, listing what is available."""
+def _strip_native_id(response):
+    """Republish the native format without an artifact id (treated unavailable)."""
+    response["output"]["compilation"]["compiled_circuits"] = {
+        "ionq.native.v1": {"format": "ionq.native.v1", "media_type": "application/json"}
+    }
+    return response
+
+
+@pytest.mark.parametrize(
+    "mutate, lang",
+    [
+        (lambda r: r, "mir"),  # lang matches no published format
+        (lambda r: {**r, "output": None}, "native"),  # nothing published (prod)
+        (_strip_native_id, "native"),  # published format lacks an id
+    ],
+)
+def test_compiled_unavailable(mock_backend, requests_mock, mutate, lang):
+    """compiled_circuit() raises IonQJobError when no usable artifact matches."""
     job_id = "dry_run_id"
     requests_mock.get(
         mock_backend.client.make_path("jobs", job_id),
-        json=_dry_run_job_response(job_id),
+        json=mutate(_dry_run_job_response(job_id)),
     )
     job = ionq_job.IonQJob(mock_backend, job_id)
     with pytest.raises(exceptions.IonQJobError, match="Available formats"):
-        job.compiled_circuit(lang="mir")
+        job.compiled_circuit(lang=lang)
 
 
 def test_compiled_artifact_error(mock_backend, requests_mock):
@@ -1464,29 +1480,3 @@ def test_qasm3_memory_false(mock_backend, requests_mock):
     assert res.data(0).get("memory") is None
     with pytest.raises(exceptions.IonQBackendError, match="memory=True"):
         job.get_memory()
-
-
-def test_compiled_no_output(mock_backend, requests_mock):
-    """A job with no published compiled_circuits raises a clear IonQJobError."""
-    job_id = "dry_run_id"
-    response = _dry_run_job_response(job_id)
-    response["output"] = None  # prod mid-rollout: endpoint 410'd, artifacts absent
-    requests_mock.get(mock_backend.client.make_path("jobs", job_id), json=response)
-
-    job = ionq_job.IonQJob(mock_backend, job_id)
-    with pytest.raises(exceptions.IonQJobError, match="Available formats: none"):
-        job.compiled_circuit()
-
-
-def test_compiled_format_no_id(mock_backend, requests_mock):
-    """A published format whose artifact lacks an id is treated as unavailable."""
-    job_id = "dry_run_id"
-    response = _dry_run_job_response(job_id)
-    response["output"]["compilation"]["compiled_circuits"] = {
-        "ionq.native.v1": {"format": "ionq.native.v1", "media_type": "application/json"}
-    }
-    requests_mock.get(mock_backend.client.make_path("jobs", job_id), json=response)
-
-    job = ionq_job.IonQJob(mock_backend, job_id)
-    with pytest.raises(exceptions.IonQJobError, match="Available formats"):
-        job.compiled_circuit(lang="native")


### PR DESCRIPTION
## What

Adds **mid-circuit measurement** and adopts the IonQ **artifacts endpoint** for results and compiled circuits the legacy per-`lang` endpoints no longer serve.

```python
qr, mid, result = QuantumRegister(1, "q"), ClassicalRegister(1, "mid"), ClassicalRegister(2, "result")
qc = QuantumCircuit(qr, mid, result)
qc.h(0)
qc.measure(0, mid[0])      # mid-circuit measurement
qc.x(0)
qc.measure(0, result[0])   # qubit reused after measurement
qc.x(0)
qc.measure(0, result[1])

res = backend.run(qc, shots=100, memory=True).result()
res.get_counts()   # register-split, e.g. {'00 0': 75, '01 1': 25}
```

## How

- **Routing** — `circuit_requires_qasm3()` detects qubit-reuse-after-measure, `reset`, and control flow; such circuits serialize to `ionq.qasm3.v1` (OpenQASM 3 via `qiskit.qasm3.dumps`) instead of raising. Everything else is unchanged (`ionq.circuit.v1`).
- **Results** — per-register shots from the v2 artifact are folded into Qiskit register-split `get_counts()`/`get_memory()` via the header's `clbit_labels`; the system-appended `output_all` is excluded.
- **Compiled circuits** — `/jobs/{id}/circuits/{lang}` now returns **410 Gone** (prod + staging); `compiled_circuit(lang)` resolves the format under `output.compilation.compiled_circuits` and fetches it via the shared `get_artifact()` primitive (the dead client method is removed).

## Notes / guards

- Single-circuit only; QASM 3 executes on the simulator and MCM-capable QPUs (Tempo) and is rejected elsewhere server-side.
- Classical-register names that `qasm3.dumps` renames to dodge OpenQASM 3 reserved words (`output` → `output_0`) are rejected at submission — a silent rename would corrupt that register's results.
- `_build_settings()` assembles the settings/`error_mitigation` block for both submission paths (also fixes a v1/qasm3 divergence on `symmetry_verification`).

## Validation

413 tests pass (incl. live end-to-end against the IonQ API where the job type is enabled); pylint 10.00/10; ruff + ruff-format + mypy clean. Prod has 410'd the old circuits endpoint but its compiler doesn't emit the artifacts yet (`compiled_circuits: null`), so `compiled_circuit()` raises a clear "no compiled circuit" error there until the API side finishes rolling out.
