### PR TITLE
fix: clear error for mid-circuit measurement on the ideal simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ The ideal simulator does not produce per-shot data; calling `get_memory()` on a 
 
 ### Mid-circuit measurements
 
-The IonQ provider supports circuits with mid-circuit measurements, qubit reuse after measurement, mid-circuit `reset`, and classical control flow. Outcomes are reported per declared classical register, matching Qiskit's usual register-split formatting. Single-circuit submissions only; pass `error_mitigation`/`symmetry_verification`, `include_leakage`, or `verbatim` via `job_settings`.
+The IonQ provider supports mid-circuit measurements, qubit reuse, mid-circuit `reset`, and classical control flow. Results are reported per declared classical register, like Qiskit's usual register-split counts. Single-circuit only; pass `error_mitigation`/`symmetry_verification`, `include_leakage`, or `verbatim` via `job_settings`.
 
-Such circuits are submitted automatically as OpenQASM 3 (`ionq.qasm3.v1`) — no extra flags needed. OpenQASM 3 jobs run on the simulator and mid-circuit-measurement-capable QPUs (Tempo); other targets reject them server-side. Classical-register names that collide with OpenQASM 3 reserved words (e.g. `output`, `input`, `measure`) are rejected at submission — rename them.
+These run automatically as OpenQASM 3 (`ionq.qasm3.v1`) on the simulator and QPUs that support it (Tempo); other targets are rejected server-side. Register names that are OpenQASM 3 reserved words (`output`, `input`, `measure`, …) are rejected at submission.
+
+Per-register results require sampling, so use a QPU or a noisy simulator (`noise_model=...`); the ideal simulator returns only the aggregate distribution and `result()` raises there.
 
 ```python
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
@@ -139,9 +141,9 @@ qc.measure(0, result[0])       # qubit reused after measurement
 qc.x(0)
 qc.measure(0, result[1])
 
-job = backend.run(qc, shots=100, memory=True)
+job = backend.run(qc, shots=100, memory=True, noise_model="aria-1")
 result = job.result()
-result.get_counts()        # split across registers, e.g. {'10 0': 50, '10 1': 50}
+result.get_counts()        # split across registers, e.g. {'10 0': 48, '10 1': 52}
 result.get_memory()        # per-shot, e.g. ['10 0', '10 1', ...]
 ```
 

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -672,8 +672,10 @@ class IonQJob(JobV1):
         """Fetch the per-register shots array for a qasm3 (MCM) job."""
         if not self._shots_artifact_id:
             raise exceptions.IonQJobError(
-                f"Job {self._job_id} reported no per-register shots artifact; "
-                "cannot build mid-circuit measurement results."
+                f"Job {self._job_id} produced no per-register shot data. "
+                "Mid-circuit measurement results require sampling — run on a "
+                'QPU or pass a noise model (e.g. noise_model="aria-1"); the '
+                "ideal simulator returns only the aggregate distribution."
             )
         assert self._job_id is not None
         payload = self._client.get_artifact(

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1454,17 +1454,25 @@ def test_qasm3_result_counts(mock_backend, requests_mock):
     assert res.get_memory() == ["00 0", "00 0", "00 0", "01 1"]
 
 
-def test_qasm3_no_shots_artifact(mock_backend, requests_mock):
-    """A qasm3 job missing its v2 shots artifact raises a clear error."""
-    job_id = "mcm_job_2"
+def test_qasm3_ideal_sim_no_shots(mock_backend, requests_mock):
+    """The ideal simulator publishes only aggregate probabilities (no shots), so
+    result() raises an actionable error pointing to a noise model / QPU."""
+    job_id = "mcm_ideal"
     response = _qasm3_job_response(job_id, "unused")
-    response["results"].pop("ionq.result.shots.json.v2")
+    response["results"] = {
+        "probabilities": {"url": f"/v0.4/jobs/{job_id}/results/probabilities"},
+        "ionq.result.probabilities.json.v2": {
+            "id": "probs-aid",
+            "format": "ionq.result.probabilities.json.v2",
+            "media_type": "application/json",
+        },
+    }
     client = mock_backend.client
     requests_mock.post(client.make_path("jobs"), json={"id": job_id})
     requests_mock.get(client.make_path("jobs", job_id), json=response)
 
     job = mock_backend.run(_mcm_circuit(), shots=4)
-    with pytest.raises(exceptions.IonQJobError, match="shots artifact"):
+    with pytest.raises(exceptions.IonQJobError, match="noise model"):
         job.result()
 
 


### PR DESCRIPTION
## What

Follow-up to #258. A mid-circuit-measurement job run on the **ideal** simulator (the default) completes but `result()` raised a confusing error:

```
IonQJobError: ... reported no per-register shots artifact ...
```

## Why

Per-register MCM outcomes come from **sampling** — only the `shots` artifact carries the `mid`/`result` registers. The ideal simulator returns only an aggregate `probabilities` artifact (`registers: {output_all: {...}}`), so the per-register data genuinely isn't there. It works on a QPU or a **noisy** simulator (which produce shots). This slipped through because the unit tests mocked a shots artifact and every live run used a noise model.

## Fix

- Replace the error with an actionable one: per-register results need a QPU or a `noise_model`; the ideal sim returns only the aggregate distribution.
- README: state the constraint and run the example with `noise_model="aria-1"` so the documented path works.
- Test the real ideal-sim results shape (probabilities-only, no shots).

Verified live against production: ideal sim → the clear error; noisy sim (`noise_model="aria-1"`) → register-split counts. 416 tests pass; pylint/ruff/mypy clean.

## Note

I considered falling back to the `output_all` aggregate so the ideal-sim case returns *something*, but that's not the per-register result the feature promises (different registers, not register-split), so a clear error + working noisy-sim path is the honest behavior. Open to the aggregate fallback if you'd prefer it.
