### PR TITLE
fix: pin compilation.service_version v0.4 for OpenQASM 3 jobs (1.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ The ideal simulator does not produce per-shot data; calling `get_memory()` on a 
 
 ### Mid-circuit measurements
 
-The IonQ provider supports mid-circuit measurements, qubit reuse, mid-circuit `reset`, and classical control flow. Results are reported per declared classical register, like Qiskit's usual register-split counts. Single-circuit only; pass `error_mitigation`/`symmetry_verification`, `include_leakage`, or `verbatim` via `job_settings`.
+The IonQ provider supports mid-circuit measurements, qubit reuse, and mid-circuit `reset`. Results are reported per declared classical register, like Qiskit's usual register-split counts. Single-circuit only; pass `error_mitigation`/`symmetry_verification` via `job_settings`.
 
-These run automatically as OpenQASM 3 (`ionq.qasm3.v1`) on the simulator and QPUs that support it (Tempo); other targets are rejected server-side. Register names that are OpenQASM 3 reserved words (`output`, `input`, `measure`, …) are rejected at submission.
+These run automatically as OpenQASM 3 (`ionq.qasm3.v1`); no extra flags needed. Today they execute on the simulator (mid-circuit-measurement QPU support is rolling out); other targets are rejected server-side. Register names that are OpenQASM 3 reserved words (`output`, `input`, `measure`, …) are rejected at submission.
 
-Per-register results require sampling, so use a QPU or a noisy simulator (`noise_model=...`); the ideal simulator returns only the aggregate distribution and `result()` raises there.
+Per-register results require sampling, so use a noisy simulator (`noise_model=...`) or a QPU; the ideal simulator returns only the aggregate distribution and `result()` raises there.
 
 ```python
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
@@ -135,16 +135,15 @@ qc = QuantumCircuit(qr, mid, result)
 
 qc.h(0)
 qc.measure(0, mid[0])          # mid-circuit measurement
-with qc.if_test((mid, 1)):      # classical control flow on the outcome
-    qc.x(0)
+qc.x(0)
 qc.measure(0, result[0])       # qubit reused after measurement
 qc.x(0)
 qc.measure(0, result[1])
 
 job = backend.run(qc, shots=100, memory=True, noise_model="aria-1")
 result = job.result()
-result.get_counts()        # split across registers, e.g. {'10 0': 48, '10 1': 52}
-result.get_memory()        # per-shot, e.g. ['10 0', '10 1', ...]
+result.get_counts()        # split across registers, e.g. {'01 0': 96, '10 1': 104}
+result.get_memory()        # per-shot, e.g. ['01 0', '10 1', ...]
 ```
 
 ### Basis gates and transpilation

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ provider = IonQProvider("token")
 
 ### Credential Environment Variables
 
-Alternatively, the IonQ Provider can discover your access token from environment variables:
+Alternatively, the IonQ Provider can discover your access token from environment variables. It checks `QISKIT_IONQ_API_TOKEN`, then `IONQ_API_KEY`, then `IONQ_API_TOKEN`:
 
 ```bash
-export IONQ_API_TOKEN="token"
+export IONQ_API_KEY="token"
 ```
 
 Then invoke instantiate the provider without any arguments:
@@ -97,14 +97,13 @@ Set `dry_run=True` on `backend.run(...)` and then read the compiled circuit back
 ```python
 backend = provider.get_backend("ionq_qpu.forte-1")
 
-job = backend.run(qc, dry_run=True)
+job = backend.run(qc, dry_run=True, job_settings={"compilation": {"service_version": "v0.4"}})
 job.wait_for_final_state()
 
 native = job.compiled_circuit(lang="native")   # IonQ-native gate JSON (dict)
-ore    = job.compiled_circuit(lang="ore")      # lower-level ORE JSON (dict)
 ```
 
-The compiled circuit is fetched from the job's published artifacts (`output.compilation.compiled_circuits`); `lang` is matched against the available format keys (e.g. `"native"` → `ionq.native.v1`). The available formats vary by job and compiler — if the requested one isn't published, `IonQJobError` lists what is. Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
+The compiled circuit is fetched from the job's published artifacts (`output.compilation.compiled_circuits`); `lang` is matched against the available format keys (e.g. `"native"` → `ionq.native.v1`). Compiled-circuit artifacts come from the v0.4 compiler stack, which is rolling out as the prod default — until then, pass `service_version="v0.4"` as above, otherwise no compiled circuit is published and `compiled_circuit()` raises listing the available formats (`none`). Dry-run jobs produce no measurement results, so calling `job.result()` on one raises `IonQJobError` directing you to `compiled_circuit(...)`.
 
 ### Per-shot memory (`memory`)
 

--- a/docs/guides/install.rst
+++ b/docs/guides/install.rst
@@ -30,9 +30,9 @@ To instantiate the provider, make sure you have an access token then create a pr
 Credential Environment Variable
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Alternatively, the IonQ Provider can discover your access token using the ``IONQ_API_TOKEN`` environment variable::
+Alternatively, the IonQ Provider can discover your access token from an environment variable. It checks ``QISKIT_IONQ_API_TOKEN``, then ``IONQ_API_KEY``, then ``IONQ_API_TOKEN``::
 
-   export IONQ_API_TOKEN="token"
+   export IONQ_API_KEY="token"
 
 Then instantiate the provider without any arguments::
 

--- a/docs/guides/usage.rst
+++ b/docs/guides/usage.rst
@@ -22,6 +22,37 @@ For example, running a Bell State:
    print(job.get_counts())
 
 
+Per-shot memory
+===============
+
+Pass ``memory=True`` to get per-shot bitstrings back from QPU or noisy-simulator
+jobs (the ideal simulator returns probabilities, not shots)::
+
+   job = simulator_backend.run(qc, shots=1000, memory=True)
+   print(job.get_memory())
+
+
+Mid-circuit measurements
+========================
+
+Circuits that measure a qubit and then reuse it, or use a mid-circuit ``reset``,
+are submitted automatically as OpenQASM 3, with results reported per declared
+classical register. Per-register results require sampling, so use a QPU or a noisy
+simulator (``noise_model="aria-1"``); the ideal simulator returns only the
+aggregate distribution.
+
+
+Compilation as a service
+========================
+
+Submit with ``dry_run=True`` to compile a circuit without running it, then read the
+compiled output back::
+
+   job = qpu_backend.run(qc, dry_run=True, job_settings={"compilation": {"service_version": "v0.4"}})
+   job.wait_for_final_state()
+   print(job.compiled_circuit(lang="native"))
+
+
 Basis gates and transpilation
 =============================
 

--- a/example/example.ipynb
+++ b/example/example.ipynb
@@ -38,7 +38,7 @@
    "source": [
     "## Usage & Examples\n",
     "\n",
-    "**NOTE**: The provider expects an API key to be supplied via the `token` keyword argument to its constructor. If no token is directly provided, the provider will check for one in the `IONQ_API_TOKEN` environment variable.\n",
+    "**NOTE**: The provider expects an API key to be supplied via the `token` keyword argument to its constructor. If no token is directly provided, the provider will check for one in the `IONQ_API_KEY` environment variable (it also accepts `QISKIT_IONQ_API_TOKEN` or `IONQ_API_TOKEN`).\n",
     "\n",
     "Now that the Python package has been installed, you can import and instantiate the provider:"
    ]

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -216,19 +216,23 @@ class IonQGateError(IonQError, JobError):
 
 
 class IonQMidCircuitMeasurementError(IonQError, JobError):
-    """Errors generated from attempting mid-circuit measurement, which is not supported.
-    Measurement must come after all instructions.
+    """A qubit is used after measurement while building a flat ``ionq.circuit.v1``
+    circuit, which can't represent mid-circuit measurement.
+
+    ``backend.run`` submits such circuits as OpenQASM 3 automatically, so this is
+    only raised when building a v1 circuit directly.
 
     Attributes:
-        qubit_index: The qubit index to be measured mid-circuit
+        qubit_index: The qubit reused after measurement.
     """
 
     def __init__(self, qubit_index: int, gate_name: str):
         self.qubit_index = qubit_index
         self.gate_name = gate_name
         super().__init__(
-            f"Attempting to put '{gate_name}' after a measurement on qubit {qubit_index}. "
-            "Mid-circuit measurement is not supported."
+            f"'{gate_name}' acts on qubit {qubit_index} after it was measured. The "
+            "ionq.circuit.v1 format can't represent mid-circuit measurement; submit "
+            "via backend.run, which uses OpenQASM 3 for such circuits."
         )
 
     def __str__(self):

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -160,8 +160,10 @@ def native_2q_gate(value: str | None) -> Literal["ms", "zz"] | None:
 
 
 def circuit_requires_qasm3(input_circuit: QuantumCircuit) -> bool:
-    """True for mid-circuit measurement, reset, or control flow (not
-    expressible as a flat v1 gate list, so submitted as OpenQASM 3).
+    """True for circuits the flat v1 gate list can't express -- mid-circuit
+    measurement, reset, or control flow -- which are submitted as OpenQASM 3.
+
+    Control flow is detected and routed, but isn't supported server-side yet.
     """
     measured: set[int] = set()
     for inst in input_circuit.data:
@@ -202,7 +204,9 @@ def qiskit_circ_to_ionq_circ(
 
     Raises:
         IonQGateError: If an unsupported instruction is supplied.
-        IonQMidCircuitMeasurementError: If a mid-circuit measurement is detected.
+        IonQMidCircuitMeasurementError: If a qubit is used after measurement. The
+          flat v1 format can't express this; ``backend.run`` routes such circuits
+          to OpenQASM 3, so this only fires when this builder is called directly.
         IonQPauliExponentialError: If non-commuting PauliExponentials are found without
           the appropriate flag.
 
@@ -777,9 +781,9 @@ class SafeEncoder(json.JSONEncoder):
 def resolve_credentials(token: str | None = None, url: str | None = None) -> dict:
     """Resolve credentials for use in IonQ API calls.
 
-    If the provided ``token`` and ``url`` are both ``None``, then these values
-    are loaded from the ``IONQ_API_TOKEN`` and ``IONQ_API_URL``
-    environment variables, respectively.
+    If the provided ``token`` and ``url`` are both ``None``, the token is read
+    from ``IONQ_API_KEY`` (also ``QISKIT_IONQ_API_TOKEN`` or ``IONQ_API_TOKEN``)
+    and the url from ``IONQ_API_URL`` (or ``QISKIT_IONQ_API_URL``).
 
     If no url is discovered, then ``https://api.ionq.co/v0.4`` is used.
 

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -550,8 +550,12 @@ def _qiskit_to_qasm3_json(  # pylint: disable=too-many-positional-arguments
         }
 
     settings = _build_settings(passed_args, backend)
-    if settings:
-        ionq_json["settings"] = settings
+    # OpenQASM 3 jobs need the v0.4 compiler stack to return register-named
+    # results; pin it unless the caller set their own service_version.
+    compilation = dict(settings.get("compilation") or {})
+    compilation.setdefault("service_version", "v0.4")
+    settings["compilation"] = compilation
+    ionq_json["settings"] = settings
 
     if passed_args.get("dry_run"):
         ionq_json["dry_run"] = True
@@ -594,9 +598,8 @@ def qiskit_to_ionq(
     if any(circuit_requires_qasm3(c) for c in circuits_to_check):
         if multi_circuit:
             raise ionq_exceptions.IonQJobError(
-                "Mid-circuit measurement, reset, and classical control flow are "
-                "only supported for single-circuit submissions. Submit such "
-                "circuits in separate jobs."
+                "Mid-circuit measurement and reset are only supported for "
+                "single-circuit submissions. Submit such circuits in separate jobs."
             )
         return _qiskit_to_qasm3_json(
             circuit,

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -206,7 +206,7 @@ class IonQBackend(Backend):
 
     @property
     def _api_backend_name(self) -> str:
-        """Backend name used by the IonQ API (e.g., `qpu.aria-1`)."""
+        """Backend name used by the IonQ API (e.g., `qpu.forte-1`)."""
         # QPU names are `ionq_qpu.*` locally; API expects `qpu.*`
         return self.name.replace("ionq_qpu", "qpu")
 
@@ -402,7 +402,7 @@ class IonQSimulatorBackend(IonQBackend):
 
 
 class IonQQPUBackend(IonQBackend):
-    """IonQ trapped-ion hardware back-ends (Aria/Alpine: MS; Forte: ZZ)."""
+    """IonQ trapped-ion hardware back-ends (Aria: MS; Forte: ZZ)."""
 
     def __init__(
         self,

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -408,7 +408,7 @@ class Characterization:
 
     @property
     def backend(self) -> str:
-        """Backend name, e.g. `"qpu.aria-1"`."""
+        """Backend name, e.g. `"qpu.forte-1"`."""
         return self._data["backend"]
 
     @property

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, patch
-VERSION_INFO = ".".join(map(str, (1, 1, 0)))
+VERSION_INFO = ".".join(map(str, (1, 1, 1)))
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -555,21 +555,36 @@ def test_qasm3_payload_shape(qpu_backend):
 
 
 def test_qasm3_settings_passthrough(qpu_backend):
-    """job_settings and error_mitigation flow through on the qasm3 path."""
+    """job_settings flow through and the ErrorMitigation enum merges in."""
     args = {
         "shots": 10,
-        "job_settings": {
-            "include_leakage": False,
-            "error_mitigation": {"symmetry_verification": True},
-        },
+        "job_settings": {"error_mitigation": {"symmetry_verification": True}},
         "error_mitigation": ErrorMitigation.NO_DEBIASING,
     }
     payload = json.loads(qiskit_to_ionq(_mcm_circuit(), qpu_backend, passed_args=args))
-    assert payload["settings"]["include_leakage"] is False
     assert payload["settings"]["error_mitigation"] == {
         "symmetry_verification": True,
         "debiasing": False,
     }
+
+
+def test_qasm3_service_version(qpu_backend):
+    """qasm3 jobs pin compilation.service_version v0.4; a caller can override."""
+    default = json.loads(
+        qiskit_to_ionq(_mcm_circuit(), qpu_backend, passed_args={"shots": 10})
+    )
+    assert default["settings"]["compilation"]["service_version"] == "v0.4"
+    override = json.loads(
+        qiskit_to_ionq(
+            _mcm_circuit(),
+            qpu_backend,
+            passed_args={
+                "shots": 10,
+                "job_settings": {"compilation": {"service_version": "v0.5"}},
+            },
+        )
+    )
+    assert override["settings"]["compilation"]["service_version"] == "v0.5"
 
 
 def test_multi_circuit_mcm_raises(qpu_backend):


### PR DESCRIPTION
## What

`1.1.1` patch. Fixes mid-circuit-measurement results coming back **all-zeros** on production, and removes mention of features the platform doesn't support yet.

## Root cause

MCM (`ionq.qasm3.v1`) jobs only return **register-named** per-register results when compiled by the **v0.4 compiler stack**. The SDK wasn't setting `settings.compilation.service_version`, so prod compiled with the older default and returned index-flattened registers (`c0`, `c1`, …) instead of `mid`/`result`. The name-based decoder then read every register as `0` → silently wrong counts. (The platform plans to make v0.4 the default "soon," but there's no date — so the client must pin it.)

## Fix

- **Pin `settings.compilation.service_version = "v0.4"` on the OpenQASM 3 path** (caller-overridable). Verified live on the prod simulator: registers come back as `mid`/`result`/`output_all` and `get_counts()` is correct (e.g. `{'01 0': 108, '10 1': 92}`).
- **Docs:** drop `control flow`, `include_leakage`, and `verbatim` (not supported in this phase); note MCM runs on the **simulator** today (per-register shots need a `noise_model`); QPU support is rolling out.
- Bump to `1.1.1`.

## Notes
- The decoder is unchanged and correct for v0.4 output; this is purely about asking the server for that output.
- Control-flow circuits are still routed to the OpenQASM 3 path (the only path that could ever express them); they're just no longer advertised.
- Tests cover the `service_version` default + caller override; full suite green (417), pylint/ruff/mypy clean.
