### PR TITLE
Support Qiskit v1 and v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,47 @@ permissions:
   contents: read
 jobs:
   tests:
-    name: python-${{ matrix.python-version }}-${{ matrix.os }}
+    name: python-${{ matrix.python-version }}-qiskit-${{ matrix.qiskit-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
+        tox-env:
+          [
+            "py310-qiskit1",
+            "py310-qiskit2",
+            "py311-qiskit1",
+            "py311-qiskit2",
+            "py312-qiskit1",
+            "py312-qiskit2",
+            "py313-qiskit1",
+            "py313-qiskit2",
+          ]
+        include:
+          - tox-env: "py310-qiskit1"
+            python-version: "3.10"
+            qiskit-version: "1"
+          - tox-env: "py310-qiskit2"
+            python-version: "3.10"
+            qiskit-version: "2"
+          - tox-env: "py311-qiskit1"
+            python-version: "3.11"
+            qiskit-version: "1"
+          - tox-env: "py311-qiskit2"
+            python-version: "3.11"
+            qiskit-version: "2"
+          - tox-env: "py312-qiskit1"
+            python-version: "3.12"
+            qiskit-version: "1"
+          - tox-env: "py312-qiskit2"
+            python-version: "3.12"
+            qiskit-version: "2"
+          - tox-env: "py313-qiskit1"
+            python-version: "3.13"
+            qiskit-version: "1"
+          - tox-env: "py313-qiskit2"
+            python-version: "3.13"
+            qiskit-version: "2"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,9 +60,8 @@ jobs:
       - name: install-requirements
         run: |
           python -m pip install --upgrade pip tox tox-gh-actions
-          python -m pip install -e .
       - name: run-tests
-        run: tox
+        run: tox -e ${{ matrix.tox-env }}
   lint:
     name: lint
     runs-on: ubuntu-latest
@@ -42,7 +76,6 @@ jobs:
       - name: install-requirements
         run: |
           python -m pip install --upgrade pip tox tox-gh-actions
-          python -m pip install -e .
       - name: lint
         run: tox -e lint
   docs:
@@ -59,7 +92,6 @@ jobs:
       - name: install-requirements
         run: |
           python -m pip install --upgrade pip tox tox-gh-actions
-          python -m pip install -e .
       - name: docs
         run: tox -e docs
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install-requirements
         run: |
-          python -m pip install --upgrade pip tox tox-gh-actions
+          python -m pip install --upgrade pip tox
       - name: run-tests
         run: tox -e ${{ matrix.tox-env }}
   lint:
@@ -75,7 +75,7 @@ jobs:
           python-version: 3.12
       - name: install-requirements
         run: |
-          python -m pip install --upgrade pip tox tox-gh-actions
+          python -m pip install --upgrade pip tox
       - name: lint
         run: tox -e lint
   docs:
@@ -91,7 +91,7 @@ jobs:
           python-version: 3.13
       - name: install-requirements
         run: |
-          python -m pip install --upgrade pip tox tox-gh-actions
+          python -m pip install --upgrade pip tox
       - name: docs
         run: tox -e docs
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ Alternatively, you may use the setuptools integration by running tests through `
 python setup.py test --addopts="[pytest-args]"
 ```
 
+To run the Qiskit compatibility matrix locally, use tox factors:
+
+```bash
+tox -e py313-qiskit1,py313-qiskit2
+```
+
 ### Fixtures
 
 Global pytest fixtures for the test suite can be found in the top-level [test/conftest.py](./test/conftest.py) file.

--- a/qiskit_ionq/_qiskit_compat.py
+++ b/qiskit_ionq/_qiskit_compat.py
@@ -1,0 +1,82 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2026 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qiskit v1/v2 compatibility helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from qiskit.quantum_info import SparsePauliOp
+
+try:
+    from qiskit.result import MeasLevel
+except ImportError:
+    MEAS_LEVEL_CLASSIFIED = 2
+else:
+    MEAS_LEVEL_CLASSIFIED = MeasLevel.CLASSIFIED
+
+SUPPORTS_SPARSE_OBSERVABLE_PAULI_EVOLUTION = hasattr(
+    SparsePauliOp, "from_sparse_observable"
+)
+
+
+class ResultHeader(dict):
+    """Dict header that also satisfies Qiskit v1 ``to_dict`` calls."""
+
+    def to_dict(self) -> dict:
+        """Return the header as a plain dict."""
+        return dict(self)
+
+
+def header_to_dict(header: Any) -> dict | None:
+    """Return a result header as a plain dict across Qiskit versions."""
+    if header is None:
+        return None
+    if isinstance(header, dict):
+        return header
+    if hasattr(header, "to_dict"):
+        return header.to_dict()
+    return dict(header)
+
+
+def normalize_result_headers(result: Any) -> Any:
+    """Normalize Qiskit Result experiment headers to dicts in v1 and v2."""
+    for experiment in getattr(result, "results", []):
+        header = getattr(experiment, "header", None)
+        if header is None or isinstance(header, dict):
+            continue
+        experiment.header = ResultHeader(header_to_dict(header))
+    return result
+
+
+__all__ = [
+    "MEAS_LEVEL_CLASSIFIED",
+    "ResultHeader",
+    "SUPPORTS_SPARSE_OBSERVABLE_PAULI_EVOLUTION",
+    "header_to_dict",
+    "normalize_result_headers",
+]

--- a/qiskit_ionq/_qiskit_compat.py
+++ b/qiskit_ionq/_qiskit_compat.py
@@ -28,7 +28,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from qiskit.quantum_info import SparsePauliOp
 
@@ -39,8 +39,13 @@ except ImportError:
 else:
     MEAS_LEVEL_CLASSIFIED = MeasLevel.CLASSIFIED
 
-SUPPORTS_SPARSE_OBSERVABLE_PAULI_EVOLUTION = hasattr(
-    SparsePauliOp, "from_sparse_observable"
+try:
+    SPARSE_PAULI_FROM_SPARSE_OBSERVABLE = SparsePauliOp.from_sparse_observable
+except AttributeError:
+    SPARSE_PAULI_FROM_SPARSE_OBSERVABLE = None
+
+SUPPORTS_SPARSE_OBSERVABLE_PAULI_EVOLUTION = (
+    SPARSE_PAULI_FROM_SPARSE_OBSERVABLE is not None
 )
 
 
@@ -58,20 +63,19 @@ def header_to_dict(header: Any) -> dict | None:
         return None
     if isinstance(header, dict):
         return header
-    if hasattr(header, "to_dict"):
+    try:
         return header.to_dict()
-    return dict(header)
+    except AttributeError:
+        return dict(header)
 
 
 def normalize_result_headers(result: Any) -> Any:
     """Normalize Qiskit Result experiment headers to dicts in v1 and v2."""
-    for experiment in getattr(result, "results", []):
-        header = getattr(experiment, "header", None)
+    for experiment in result.results:
+        header = experiment.header
         if header is None or isinstance(header, dict):
             continue
-        header_dict = header_to_dict(header)
-        if header_dict is None:
-            continue
+        header_dict = cast(dict, header_to_dict(header))
         experiment.header = ResultHeader(header_dict)
     return result
 
@@ -79,6 +83,7 @@ def normalize_result_headers(result: Any) -> Any:
 __all__ = [
     "MEAS_LEVEL_CLASSIFIED",
     "ResultHeader",
+    "SPARSE_PAULI_FROM_SPARSE_OBSERVABLE",
     "SUPPORTS_SPARSE_OBSERVABLE_PAULI_EVOLUTION",
     "header_to_dict",
     "normalize_result_headers",

--- a/qiskit_ionq/_qiskit_compat.py
+++ b/qiskit_ionq/_qiskit_compat.py
@@ -69,7 +69,10 @@ def normalize_result_headers(result: Any) -> Any:
         header = getattr(experiment, "header", None)
         if header is None or isinstance(header, dict):
             continue
-        experiment.header = ResultHeader(header_to_dict(header))
+        header_dict = header_to_dict(header)
+        if header_dict is None:
+            continue
+        experiment.header = ResultHeader(header_dict)
     return result
 
 

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -200,11 +200,17 @@ class IonQGateError(IonQError, JobError):
         gate_name: The name of the gate which caused this error.
     """
 
-    def __init__(self, gate_name: str, gateset: Literal["qis", "native"]):
+    def __init__(
+        self,
+        gate_name: str,
+        gateset: Literal["qis", "native"],
+        message: str | None = None,
+    ):
         self.gate_name = gate_name
         self.gateset = gateset
         super().__init__(
-            (
+            message
+            or (
                 f"gate '{gate_name}' is not supported on the '{gateset}' IonQ backends. "
                 "Please use the qiskit.transpile method, manually rewrite to remove the gate, "
                 "or change the gateset selection as appropriate."

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -55,12 +55,12 @@ from qiskit.circuit import (
     QuantumRegister,
     ClassicalRegister,
 )
-from qiskit.quantum_info import SparsePauliOp
 
 # Use this to get version instead of __version__ to avoid circular dependency.
 from importlib_metadata import version
 from qiskit_ionq.constants import ErrorMitigation
 from . import exceptions as ionq_exceptions
+from ._qiskit_compat import SPARSE_PAULI_FROM_SPARSE_OBSERVABLE
 
 # the qiskit gates that the IonQ backend can serialize to our IR
 # not the actual hardware basis gates for the system — we do our own transpilation pass.
@@ -324,13 +324,19 @@ def qiskit_circ_to_ionq_circ(
 
         if instruction_name == "pauliexp":
             operator = instruction.operator
-            if not hasattr(operator, "to_list"):
-                from_sparse_observable = getattr(
-                    SparsePauliOp, "from_sparse_observable", None
-                )
-                if from_sparse_observable is None:
-                    raise ionq_exceptions.IonQGateError(instruction_name, gateset)
-                operator = from_sparse_observable(operator)
+            try:
+                operator.to_list
+            except AttributeError as ex:
+                if SPARSE_PAULI_FROM_SPARSE_OBSERVABLE is None:
+                    raise ionq_exceptions.IonQGateError(
+                        instruction_name,
+                        gateset,
+                        (
+                            "SparseObservable PauliEvolutionGate requires Qiskit v2. "
+                            "For Qiskit v1, build the PauliEvolutionGate with SparsePauliOp."
+                        ),
+                    ) from ex
+                operator = SPARSE_PAULI_FROM_SPARSE_OBSERVABLE(operator)
             imag_coeff = any(coeff.imag for coeff in operator.coeffs)
             assert not imag_coeff, (
                 "PauliEvolution gate must have real coefficients, "

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -325,7 +325,12 @@ def qiskit_circ_to_ionq_circ(
         if instruction_name == "pauliexp":
             operator = instruction.operator
             if not hasattr(operator, "to_list"):
-                operator = SparsePauliOp.from_sparse_observable(operator)
+                from_sparse_observable = getattr(
+                    SparsePauliOp, "from_sparse_observable", None
+                )
+                if from_sparse_observable is None:
+                    raise ionq_exceptions.IonQGateError(instruction_name, gateset)
+                operator = from_sparse_observable(operator)
             imag_coeff = any(coeff.imag for coeff in operator.coeffs)
             assert not imag_coeff, (
                 "PauliEvolution gate must have real coefficients, "

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -47,6 +47,7 @@ from qiskit.providers.exceptions import JobTimeoutError
 from .ionq_result import IonQResult as Result
 from .helpers import decompress_metadata_string, normalize
 from .exceptions import IonQBackendError
+from ._qiskit_compat import normalize_result_headers
 
 from . import constants, exceptions
 
@@ -732,16 +733,18 @@ class IonQJob(JobV1):
             }
         ]
 
-        return Result.from_dict(
-            {
-                "results": job_result,
-                "job_id": self.job_id(),
-                "backend_name": backend.name,
-                "backend_version": backend.backend_version,
-                "qobj_id": metadata.get("qobj_id"),
-                "success": success,
-                "time_taken": self._execution_time,
-            }
+        return normalize_result_headers(
+            Result.from_dict(
+                {
+                    "results": job_result,
+                    "job_id": self.job_id(),
+                    "backend_name": backend.name,
+                    "backend_version": backend.backend_version,
+                    "qobj_id": metadata.get("qobj_id"),
+                    "success": success,
+                    "time_taken": self._execution_time,
+                }
+            )
         )
 
     def _format_result(self, data):
@@ -863,16 +866,18 @@ class IonQJob(JobV1):
                 }
 
         # Final Qiskit Result object
-        return Result.from_dict(
-            {
-                "results": job_result,
-                "job_id": self.job_id(),
-                "backend_name": backend_name,
-                "backend_version": backend_version,
-                "qobj_id": metadata.get("qobj_id"),
-                "success": success,
-                "time_taken": self._execution_time,
-            }
+        return normalize_result_headers(
+            Result.from_dict(
+                {
+                    "results": job_result,
+                    "job_id": self.job_id(),
+                    "backend_name": backend_name,
+                    "backend_version": backend_version,
+                    "qobj_id": metadata.get("qobj_id"),
+                    "success": success,
+                    "time_taken": self._execution_time,
+                }
+            )
         )
 
     def _save_metadata(self, response):

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -47,7 +47,6 @@ from qiskit.providers.exceptions import JobTimeoutError
 from .ionq_result import IonQResult as Result
 from .helpers import decompress_metadata_string, normalize
 from .exceptions import IonQBackendError
-from ._qiskit_compat import normalize_result_headers
 
 from . import constants, exceptions
 
@@ -733,18 +732,16 @@ class IonQJob(JobV1):
             }
         ]
 
-        return normalize_result_headers(
-            Result.from_dict(
-                {
-                    "results": job_result,
-                    "job_id": self.job_id(),
-                    "backend_name": backend.name,
-                    "backend_version": backend.backend_version,
-                    "qobj_id": metadata.get("qobj_id"),
-                    "success": success,
-                    "time_taken": self._execution_time,
-                }
-            )
+        return Result.from_dict(
+            {
+                "results": job_result,
+                "job_id": self.job_id(),
+                "backend_name": backend.name,
+                "backend_version": backend.backend_version,
+                "qobj_id": metadata.get("qobj_id"),
+                "success": success,
+                "time_taken": self._execution_time,
+            }
         )
 
     def _format_result(self, data):
@@ -866,18 +863,16 @@ class IonQJob(JobV1):
                 }
 
         # Final Qiskit Result object
-        return normalize_result_headers(
-            Result.from_dict(
-                {
-                    "results": job_result,
-                    "job_id": self.job_id(),
-                    "backend_name": backend_name,
-                    "backend_version": backend_version,
-                    "qobj_id": metadata.get("qobj_id"),
-                    "success": success,
-                    "time_taken": self._execution_time,
-                }
-            )
+        return Result.from_dict(
+            {
+                "results": job_result,
+                "job_id": self.job_id(),
+                "backend_name": backend_name,
+                "backend_version": backend_version,
+                "qobj_id": metadata.get("qobj_id"),
+                "success": success,
+                "time_taken": self._execution_time,
+            }
         )
 
     def _save_metadata(self, response):

--- a/qiskit_ionq/ionq_result.py
+++ b/qiskit_ionq/ionq_result.py
@@ -32,6 +32,7 @@ from qiskit.exceptions import QiskitError
 from qiskit.result import Result
 from qiskit.result.counts import Counts
 from . import exceptions
+from ._qiskit_compat import header_to_dict
 
 
 class IonQResult(Result):
@@ -68,8 +69,8 @@ class IonQResult(Result):
         for key in exp_keys:
             exp = self._get_experiment(key)
             try:
-                header = exp.header.to_dict()
-            except (AttributeError, QiskitError):  # header is not available
+                header = header_to_dict(exp.header)
+            except (AttributeError, TypeError, ValueError, QiskitError):
                 header = None
 
             if "probabilities" in self.data(key).keys():

--- a/qiskit_ionq/ionq_result.py
+++ b/qiskit_ionq/ionq_result.py
@@ -32,7 +32,7 @@ from qiskit.exceptions import QiskitError
 from qiskit.result import Result
 from qiskit.result.counts import Counts
 from . import exceptions
-from ._qiskit_compat import header_to_dict
+from ._qiskit_compat import header_to_dict, normalize_result_headers
 
 
 class IonQResult(Result):
@@ -42,6 +42,11 @@ class IonQResult(Result):
     The primary reason this class extends the base Qiskit result object is to
     provide an API for retrieving result probabilities directly.
     """
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a result and normalize version-specific header objects."""
+        return normalize_result_headers(super().from_dict(data))
 
     def get_probabilities(self, experiment=None):
         """

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-qiskit>=2.0.0
+qiskit>=1.0.0,<3.0.0
 Sphinx>=4.5.0
 sphinx-tabs>=1.1.11
 sphinx-autodoc-typehints

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-qiskit[qasm3-import]>=2.0.0
+qiskit[qasm3-import]>=1.0.0,<3.0.0
 pytest
 requests-mock>=1.8.0
 pytest-cov>=2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=2.0.0
+qiskit>=1.0.0,<3.0.0
 decorator>=5.1.0
 requests>=2.24.0
 importlib-metadata>=4.11.4

--- a/test/helpers/test_gate_serialization.py
+++ b/test/helpers/test_gate_serialization.py
@@ -39,6 +39,7 @@ from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.quantum_info import SparsePauliOp, SparseObservable
 
 from qiskit_ionq import exceptions
+from qiskit_ionq import helpers as ionq_helpers
 from qiskit_ionq._qiskit_compat import (
     SUPPORTS_SPARSE_OBSERVABLE_PAULI_EVOLUTION,
 )
@@ -244,6 +245,18 @@ def test_pauliexp_circuit():
     ]
     built, _, _ = qiskit_circ_to_ionq_circ(circuit)
     assert built == expected
+
+
+def test_pauliexp_sparse_observable_unsupported_message(monkeypatch):
+    """SparseObservable on Qiskit v1 gives a targeted compatibility error."""
+    evo = PauliEvolutionGate(SparsePauliOp(["XX"], coeffs=[0.1]), time=0.4)
+    evo.operator = SparseObservable.from_list([("XX", 0.1)])
+    circuit = QuantumCircuit(2)
+    circuit.append(evo, [0, 1])
+    monkeypatch.setattr(ionq_helpers, "SPARSE_PAULI_FROM_SPARSE_OBSERVABLE", None)
+
+    with pytest.raises(exceptions.IonQGateError, match="SparseObservable.*Qiskit v2"):
+        qiskit_circ_to_ionq_circ(circuit)
 
 
 @pytest.mark.skipif(

--- a/test/helpers/test_gate_serialization.py
+++ b/test/helpers/test_gate_serialization.py
@@ -39,6 +39,9 @@ from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.quantum_info import SparsePauliOp, SparseObservable
 
 from qiskit_ionq import exceptions
+from qiskit_ionq._qiskit_compat import (
+    SUPPORTS_SPARSE_OBSERVABLE_PAULI_EVOLUTION,
+)
 from qiskit_ionq.helpers import qiskit_circ_to_ionq_circ
 
 compiler_directives = ["barrier"]
@@ -243,6 +246,10 @@ def test_pauliexp_circuit():
     assert built == expected
 
 
+@pytest.mark.skipif(
+    not SUPPORTS_SPARSE_OBSERVABLE_PAULI_EVOLUTION,
+    reason="Qiskit v1 PauliEvolutionGate does not accept SparseObservable",
+)
 def test_pauliexp_circuit_sparse_observable():
     """Test structure of circuits with a Pauli evolution gate built from SparseObservable."""
     # build the evolution gate directly from SparseObservable
@@ -264,6 +271,10 @@ def test_pauliexp_circuit_sparse_observable():
     assert built == expected
 
 
+@pytest.mark.skipif(
+    not SUPPORTS_SPARSE_OBSERVABLE_PAULI_EVOLUTION,
+    reason="Qiskit v1 PauliEvolutionGate does not accept SparseObservable",
+)
 def test_pauliexp_sparse_observable_expand():
     """Projector terms in a SparseObservable expand; coeff/term lengths must stay aligned."""
     operator = SparseObservable.from_list([("+I", 0.7), ("XX", 0.5)])

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -33,9 +33,9 @@ import pytest
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.providers import exceptions as q_exc
 from qiskit.providers import jobstatus
-from qiskit.result import MeasLevel
 
 from qiskit_ionq import exceptions, ionq_job
+from qiskit_ionq._qiskit_compat import MEAS_LEVEL_CLASSIFIED
 from qiskit_ionq.helpers import compress_to_metadata_string
 
 
@@ -456,7 +456,7 @@ expected_result = {
                 "qreg_sizes": [["q", 2]],
                 "qubit_labels": [["q", 0], ["q", 1]],
             },
-            "meas_level": MeasLevel.CLASSIFIED,
+            "meas_level": MEAS_LEVEL_CLASSIFIED,
             "shots": 1234,
             "success": True,
         }

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -37,6 +37,7 @@ from qiskit.providers import jobstatus
 from qiskit_ionq import exceptions, ionq_job
 from qiskit_ionq._qiskit_compat import MEAS_LEVEL_CLASSIFIED
 from qiskit_ionq.helpers import compress_to_metadata_string
+from qiskit_ionq.ionq_result import IonQResult
 
 
 from .. import conftest
@@ -470,6 +471,14 @@ expected_result = {
 
 
 # Validate the result
+def test_result_from_dict_headers():
+    """IonQResult.from_dict normalizes headers for Qiskit v1 and v2."""
+    result = IonQResult.from_dict(expected_result)
+
+    assert result.results[0].header["memory_slots"] == 2
+    assert result.to_dict() == expected_result
+
+
 def test_result(mock_backend, requests_mock):
     """Test basic "happy path" for result fetching.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
 [tox]
-envlist = py310, py311, py312, py313, lint, docs
+envlist = py{310,311,312,313}-qiskit{1,2}, lint, docs
 
 [gh-actions]
 python =
-  3.10: py310, mypy
-  3.11: py311, mypy
-  3.12: py312, mypy
-  3.13: py313, mypy
+  3.10: py310-qiskit1, py310-qiskit2
+  3.11: py311-qiskit1, py311-qiskit2
+  3.12: py312-qiskit1, py312-qiskit2
+  3.13: py313-qiskit1, py313-qiskit2
 
 [testenv]
 deps =
+  qiskit1: qiskit[qasm3-import]>=1.0.0,<2.0.0
+  qiskit2: qiskit[qasm3-import]>=2.0.0,<3.0.0
   .[test]
   -r requirements.txt
   -r requirements-test.txt
@@ -40,6 +42,9 @@ commands = make html
 filterwarnings =
   error::DeprecationWarning
   error::PendingDeprecationWarning
+  ignore:The method .*MCXGate.get_num_ancilla_qubits.*:PendingDeprecationWarning
+  ignore:The class .*MCX.*:PendingDeprecationWarning
+  ignore:The property .*Instruction.condition.*:DeprecationWarning
   ignore:Failed to get qubits .* Using 4:UserWarning:qiskit_ionq\.helpers
   ignore:Retrying .* more time\(s\) after .*:UserWarning:qiskit_ionq\.helpers
   ignore:TimedOut:UserWarning:qiskit_ionq\.ionq_job

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,6 @@
 [tox]
 envlist = py{310,311,312,313}-qiskit{1,2}, lint, docs
 
-[gh-actions]
-python =
-  3.10: py310-qiskit1, py310-qiskit2
-  3.11: py311-qiskit1, py311-qiskit2
-  3.12: py312-qiskit1, py312-qiskit2
-  3.13: py313-qiskit1, py313-qiskit2
-
 [testenv]
 deps =
   qiskit1: qiskit[qasm3-import]>=1.0.0,<2.0.0


### PR DESCRIPTION
## Summary
- relax Qiskit dependency pins to support both v1 and v2
- add Qiskit compatibility helpers for result headers and MeasLevel
- add tox factors and CI matrix entries for Qiskit 1/2 across supported Python versions

## Tests
- tox -e py313-qiskit1,py313-qiskit2
- tox -e lint,docs
- git diff --check