### PR TITLE
feat: API-driven backend target (Tempo support, connectivity, capabilities)

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -815,30 +815,26 @@ def api_backend_id(name: str) -> str:
     return f"qpu.{name}"
 
 
-def get_backend_config(
-    name: str, token: str | None = None, url: str | None = None
-) -> dict:
-    """Fetch a backend's static config from ``GET /backends/{id}``.
+def get_backends(token: str | None = None, url: str | None = None) -> dict[str, dict]:
+    """Fetch the ``GET /backends`` catalog, keyed by API id.
 
-    Includes qubit count, supported/native gates, and supported error-mitigation
-    techniques, so callers derive them from one request rather than hardcoding
-    per device.
-
-    Returns ``{}`` (and warns) when the endpoint is unreachable, so callers can
-    fall back to defaults.
+    One request returns every backend's static config (qubit count,
+    supported/native gates, supported error-mitigation techniques), so the
+    provider can resolve them all locally instead of querying per device.
+    Returns ``{}`` (and warns) when the endpoint is unreachable.
     """
     creds = resolve_credentials(token, url)
     headers = {"Authorization": f"apiKey {creds['token']}"} if creds["token"] else None
     try:
-        resp = requests.get(
-            f"{creds['url']}/backends/{api_backend_id(name)}",
-            headers=headers,
-            timeout=5,
-        )
+        resp = requests.get(f"{creds['url']}/backends", headers=headers, timeout=5)
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        items = data if isinstance(data, list) else (data.get("backends") or [])
+        return {
+            b["backend"]: b for b in items if isinstance(b, dict) and "backend" in b
+        }
     except Exception as exception:  # pylint: disable=broad-except
-        warnings.warn(f"Failed to fetch config for {name}: {exception}.")
+        warnings.warn(f"Failed to fetch backends catalog: {exception}.")
         return {}
 
 
@@ -924,6 +920,7 @@ __all__ = [
     "decompress_metadata_string",
     "get_user_agent",
     "resolve_credentials",
-    "get_backend_config",
+    "api_backend_id",
+    "get_backends",
     "retry",
 ]

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -145,6 +145,7 @@ GATESET_MAP = {
 NATIVE_2Q_BY_FAMILY: dict[str, Literal["ms", "zz"]] = {
     "aria": "ms",
     "forte": "zz",
+    "tempo": "zz",
 }
 
 

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -854,21 +854,15 @@ def get_backends(token: str | None = None, url: str | None = None) -> dict[str, 
     One request returns every backend's static config (qubit count,
     supported/native gates, supported error-mitigation techniques), so the
     provider can resolve them all locally instead of querying per device.
-    Returns ``{}`` (and warns) when the endpoint is unreachable.
+    Failures raise; graceful fallbacks are the caller's responsibility.
     """
     creds = resolve_credentials(token, url)
     headers = {"Authorization": f"apiKey {creds['token']}"} if creds["token"] else None
-    try:
-        resp = requests.get(f"{creds['url']}/backends", headers=headers, timeout=5)
-        resp.raise_for_status()
-        data = resp.json()
-        items = data if isinstance(data, list) else (data.get("backends") or [])
-        return {
-            b["backend"]: b for b in items if isinstance(b, dict) and "backend" in b
-        }
-    except Exception as exception:  # pylint: disable=broad-except
-        warnings.warn(f"Failed to fetch backends catalog: {exception}.")
-        return {}
+    resp = requests.get(f"{creds['url']}/backends", headers=headers, timeout=5)
+    resp.raise_for_status()
+    data = resp.json()
+    items = data if isinstance(data, list) else (data.get("backends") or [])
+    return {b["backend"]: b for b in items if isinstance(b, dict) and "backend" in b}
 
 
 def retry(

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -803,11 +803,14 @@ def resolve_credentials(token: str | None = None, url: str | None = None) -> dic
     }
 
 
-def _api_backend_id(name: str) -> str:
-    """Local name -> API id (``ionq_qpu.forte-1``/``forte-1`` -> ``qpu.forte-1``,
-    ``ionq_simulator`` -> ``simulator``)."""
+def api_backend_id(name: str) -> str:
+    """Map a local backend name to its API id.
+
+    ``ionq_qpu.forte-1``/``forte-1`` -> ``qpu.forte-1``,
+    ``ionq_simulator`` -> ``simulator``, ``ionq_qpu`` -> ``qpu``.
+    """
     name = name.removeprefix("ionq_")
-    if name == "simulator" or name.startswith("qpu."):
+    if name in ("simulator", "qpu") or name.startswith("qpu."):
         return name
     return f"qpu.{name}"
 
@@ -815,15 +818,20 @@ def _api_backend_id(name: str) -> str:
 def get_backend_config(
     name: str, token: str | None = None, url: str | None = None
 ) -> dict:
-    """Fetch a backend's static config (qubits, supported/native gates, error
-    mitigations) from ``GET /backends/{id}``; ``{}`` (with a warning) if
-    unreachable so callers can fall back to defaults.
+    """Fetch a backend's static config from ``GET /backends/{id}``.
+
+    Includes qubit count, supported/native gates, and supported error-mitigation
+    techniques, so callers derive them from one request rather than hardcoding
+    per device.
+
+    Returns ``{}`` (and warns) when the endpoint is unreachable, so callers can
+    fall back to defaults.
     """
     creds = resolve_credentials(token, url)
     headers = {"Authorization": f"apiKey {creds['token']}"} if creds["token"] else None
     try:
         resp = requests.get(
-            f"{creds['url']}/backends/{_api_backend_id(name)}",
+            f"{creds['url']}/backends/{api_backend_id(name)}",
             headers=headers,
             timeout=5,
         )

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -457,6 +457,12 @@ def _qasm3_data(circuit: QuantumCircuit) -> str:
         dumps as _qasm3_dumps,
     )
 
+    # Drop the layout so dumps emits a virtual register (qubit[n] q;), which
+    # the API requires, not physical qubits ($0).
+    if getattr(circuit, "layout", None) is not None:
+        circuit = circuit.copy()
+        circuit._layout = None  # pylint: disable=protected-access
+
     data = _qasm3_dumps(circuit)
     emitted = set(re.findall(r"\bbit(?:\[\d+\])?\s+(\w+)\s*;", data))
     renamed = [creg.name for creg in circuit.cregs if creg.name not in emitted]

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -457,8 +457,9 @@ def _qasm3_data(circuit: QuantumCircuit) -> str:
         dumps as _qasm3_dumps,
     )
 
-    # Drop the layout so dumps emits a virtual register (qubit[n] q;), which
-    # the API requires, not physical qubits ($0).
+    # Drop the layout so dumps emits a virtual register (qubit[n] q;) instead
+    # of OpenQASM 3 physical-qubit references ($0, $1, ...), which the API
+    # rejects.
     if getattr(circuit, "layout", None) is not None:
         circuit = circuit.copy()
         circuit._layout = None  # pylint: disable=protected-access
@@ -835,7 +836,8 @@ def resolve_credentials(token: str | None = None, url: str | None = None) -> dic
 
 
 def api_backend_id(name: str) -> str:
-    """Map a local backend name to its API id.
+    """Map a local backend name to its API id -- the identifier the IonQ REST
+    API uses for a backend (the ``backend`` field in ``GET /backends``).
 
     ``ionq_qpu.forte-1``/``forte-1`` -> ``qpu.forte-1``,
     ``ionq_simulator`` -> ``simulator``, ``ionq_qpu`` -> ``qpu``.

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -798,11 +798,8 @@ def resolve_credentials(token: str | None = None, url: str | None = None) -> dic
 
 
 def _api_backend_id(name: str) -> str:
-    """Map a local backend name to its API id.
-
-    ``ionq_qpu.forte-1`` -> ``qpu.forte-1``, ``ionq_simulator`` -> ``simulator``,
-    ``forte-1`` -> ``qpu.forte-1`` (also accepts noise-model names).
-    """
+    """Local name -> API id (``ionq_qpu.forte-1``/``forte-1`` -> ``qpu.forte-1``,
+    ``ionq_simulator`` -> ``simulator``)."""
     name = name.removeprefix("ionq_")
     if name == "simulator" or name.startswith("qpu."):
         return name
@@ -812,14 +809,9 @@ def _api_backend_id(name: str) -> str:
 def get_backend_config(
     name: str, token: str | None = None, url: str | None = None
 ) -> dict:
-    """Fetch a backend's static configuration from ``GET /backends/{id}``.
-
-    Returns the raw payload -- ``qubits``, ``supported_gates``,
-    ``supported_native_gates``, ``supported_error_mitigations`` and more -- so
-    callers can derive qubit count, native gateset, and capabilities from a
-    single request instead of hardcoding them per device. Returns an empty
-    dict (with a warning) when the endpoint is unreachable, letting callers
-    fall back to sensible defaults.
+    """Fetch a backend's static config (qubits, supported/native gates, error
+    mitigations) from ``GET /backends/{id}``; ``{}`` (with a warning) if
+    unreachable so callers can fall back to defaults.
     """
     creds = resolve_credentials(token, url)
     headers = {"Authorization": f"apiKey {creds['token']}"} if creds["token"] else None

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -140,25 +140,6 @@ GATESET_MAP = {
     "native": ionq_native_basis_gates,
 }
 
-# Native 2-qubit entangling gate by IonQ device family. Add a row when a
-# new family ships; consulted by IonQBackend._make_target().
-NATIVE_2Q_BY_FAMILY: dict[str, Literal["ms", "zz"]] = {
-    "aria": "ms",
-    "forte": "zz",
-    "tempo": "zz",
-}
-
-
-def native_2q_gate(value: str | None) -> Literal["ms", "zz"] | None:
-    """Pick "ms"/"zz" implied by a backend name or noise_model, else None."""
-    if not isinstance(value, str):
-        return None
-    value = value.lower()
-    for fam, gate in NATIVE_2Q_BY_FAMILY.items():
-        if value == fam or f"{fam}-" in value or value.endswith((f".{fam}", f"_{fam}")):
-            return gate
-    return None
-
 
 def circuit_requires_qasm3(input_circuit: QuantumCircuit) -> bool:
     """True for circuits the flat v1 gate list can't express -- mid-circuit
@@ -816,27 +797,43 @@ def resolve_credentials(token: str | None = None, url: str | None = None) -> dic
     }
 
 
-def get_n_qubits(backend, fallback=4):
-    """Get the number of qubits for a given backend."""
-    backend = backend.removeprefix("ionq_")
-    backend = (
-        backend
-        if backend == "simulator" or backend.startswith("qpu.")
-        else f"qpu.{backend}"
-    )
+def _api_backend_id(name: str) -> str:
+    """Map a local backend name to its API id.
+
+    ``ionq_qpu.forte-1`` -> ``qpu.forte-1``, ``ionq_simulator`` -> ``simulator``,
+    ``forte-1`` -> ``qpu.forte-1`` (also accepts noise-model names).
+    """
+    name = name.removeprefix("ionq_")
+    if name == "simulator" or name.startswith("qpu."):
+        return name
+    return f"qpu.{name}"
+
+
+def get_backend_config(
+    name: str, token: str | None = None, url: str | None = None
+) -> dict:
+    """Fetch a backend's static configuration from ``GET /backends/{id}``.
+
+    Returns the raw payload -- ``qubits``, ``supported_gates``,
+    ``supported_native_gates``, ``supported_error_mitigations`` and more -- so
+    callers can derive qubit count, native gateset, and capabilities from a
+    single request instead of hardcoding them per device. Returns an empty
+    dict (with a warning) when the endpoint is unreachable, letting callers
+    fall back to sensible defaults.
+    """
+    creds = resolve_credentials(token, url)
+    headers = {"Authorization": f"apiKey {creds['token']}"} if creds["token"] else None
     try:
-        return (
-            requests.get(
-                f"{resolve_credentials()['url']}/backends/{backend}", timeout=5
-            )
-            .json()
-            .get("qubits", fallback)
+        resp = requests.get(
+            f"{creds['url']}/backends/{_api_backend_id(name)}",
+            headers=headers,
+            timeout=5,
         )
+        resp.raise_for_status()
+        return resp.json()
     except Exception as exception:  # pylint: disable=broad-except
-        warnings.warn(
-            f"Failed to get qubits for {backend}: {exception}. Using {fallback}"
-        )
-        return fallback
+        warnings.warn(f"Failed to fetch config for {name}: {exception}.")
+        return {}
 
 
 def retry(
@@ -921,6 +918,6 @@ __all__ = [
     "decompress_metadata_string",
     "get_user_agent",
     "resolve_credentials",
-    "get_n_qubits",
+    "get_backend_config",
     "retry",
 ]

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -309,10 +309,9 @@ def qiskit_circ_to_ionq_circ(
             if not hasattr(operator, "to_list"):
                 operator = SparsePauliOp.from_sparse_observable(operator)
             imag_coeff = any(coeff.imag for coeff in operator.coeffs)
-            assert not imag_coeff, (
-                "PauliEvolution gate must have real coefficients, "
-                f"but got {imag_coeff}"
-            )
+            assert (
+                not imag_coeff
+            ), f"PauliEvolution gate must have real coefficients, but got {imag_coeff}"
             terms = [term[0] for term in operator.to_list()]
             if not ionq_compiler_synthesis and not paulis_commute(terms):
                 raise ionq_exceptions.IonQPauliExponentialError(
@@ -860,9 +859,9 @@ def get_backends(token: str | None = None, url: str | None = None) -> dict[str, 
     headers = {"Authorization": f"apiKey {creds['token']}"} if creds["token"] else None
     resp = requests.get(f"{creds['url']}/backends", headers=headers, timeout=5)
     resp.raise_for_status()
-    data = resp.json()
-    items = data if isinstance(data, list) else (data.get("backends") or [])
-    return {b["backend"]: b for b in items if isinstance(b, dict) and "backend" in b}
+    payload = resp.json()
+    backends = payload if isinstance(payload, list) else (payload.get("backends") or [])
+    return {b["backend"]: b for b in backends if isinstance(b, dict) and "backend" in b}
 
 
 def retry(

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -120,15 +120,10 @@ class IonQBackend(Backend):
         self._max_experiments: int | None = max_experiments
         self._max_shots: int | None = max_shots
 
-        # Static config (qubits, gates, capabilities) comes from the provider's
-        # cached /backends catalog. An explicit num_qubits pins the caller's
-        # own config and bypasses the catalog; otherwise a missing entry
-        # yields {} and we fall back to a small default qubit count.
-        self._config: dict = {}
-        if num_qubits is None:
-            self._config = self._provider.backend_config(name)
-            num_qubits = int(self._config.get("qubits", _DEFAULT_NUM_QUBITS))
-        self._num_qubits: int = num_qubits
+        # Catalog config resolves lazily via _get_config; an explicit
+        # num_qubits pins the caller's own config and skips the catalog.
+        self._config: dict | None = {} if num_qubits is not None else None
+        self._num_qubits: int | None = num_qubits
 
         # Target and coupling map are resolved lazily on first access, keeping
         # construction network-free.
@@ -178,6 +173,10 @@ class IonQBackend(Backend):
 
     @property
     def num_qubits(self) -> int:
+        if self._num_qubits is None:
+            self._num_qubits = int(
+                self._get_config().get("qubits", _DEFAULT_NUM_QUBITS)
+            )
         return self._num_qubits
 
     @property
@@ -185,15 +184,23 @@ class IonQBackend(Backend):
         """Return the basis gates for this backend."""
         return self._basis_gates
 
+    def _get_config(self) -> dict:
+        """Catalog entry for this backend, resolved once via the provider;
+        ``{}`` when unavailable."""
+        if self._config is None:
+            self._config = self._provider.get_backend_config(self.name)
+        return self._config
+
     def _config_list(self, key: str) -> list[str]:
         """Read a list-valued key from the API config, warning when the config
         is unavailable so an empty result is distinguishable from "none"."""
-        if not self._config:
+        config = self._get_config()
+        if not config:
             warnings.warn(
                 f"No API config available for backend {self.name!r}; "
                 f"{key} is unknown (returning an empty list)."
             )
-        return list(self._config.get(key) or [])
+        return list(config.get(key) or [])
 
     @property
     def supported_gates(self) -> list[str]:
@@ -380,7 +387,7 @@ class IonQBackend(Backend):
         if self._coupling_map is not None:
             return self._coupling_map
 
-        n = self._num_qubits
+        n = self.num_qubits
         pairs = self._fetch_connectivity()
         if pairs:
             # Collect into a set (symmetrize + dedupe + bounds-check) so we can
@@ -410,7 +417,7 @@ class IonQBackend(Backend):
     def _make_target(self) -> Target:
         """Build a Target of QIS or native gates, scoping 2q gates to the coupling
         map on restricted topologies (else use all-to-all connectivity)."""
-        tgt = Target(num_qubits=self._num_qubits)
+        tgt = Target(num_qubits=self.num_qubits)
 
         self._get_coupling_map()
         two_q_props = (
@@ -491,12 +498,13 @@ class IonQBackend(Backend):
     def _two_q_native_gate(self) -> Literal["ms", "zz"]:
         """Native 2q gate from ``supported_native_gates`` (the simulator follows
         its noise model); defaults to ``"ms"`` for ideal-sim and offline."""
-        config = self._config
         if self._simulator:
             noise_model = getattr(self.options, "noise_model", None)
             if not noise_model or noise_model == "ideal":
                 return "ms"
-            config = self._provider.backend_config(noise_model)
+            config = self._provider.get_backend_config(noise_model)
+        else:
+            config = self._get_config()
         return "zz" if "zz" in (config.get("supported_native_gates") or []) else "ms"
 
     @staticmethod

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -71,11 +71,20 @@ from qiskit.transpiler import Target, CouplingMap
 
 from qiskit_ionq.ionq_gates import GPIGate, GPI2Gate, MSGate, ZZGate
 from . import ionq_equivalence_library, ionq_job, ionq_client, exceptions
-from .helpers import GATESET_MAP, get_backend_config, warn_bad_transpile_level
+from .helpers import (
+    GATESET_MAP,
+    api_backend_id,
+    get_backend_config,
+    warn_bad_transpile_level,
+)
 from .ionq_client import Characterization
 
 if TYPE_CHECKING:  # pragma: no cover
     from .ionq_provider import IonQProvider
+
+# Fallback qubit count when GET /backends/{id} is unreachable (offline), so a
+# Target can still be built; real counts come from the API.
+_DEFAULT_NUM_QUBITS = 4
 
 
 class IonQBackend(Backend):
@@ -115,23 +124,24 @@ class IonQBackend(Backend):
         self._max_experiments: int | None = max_experiments
         self._max_shots: int | None = max_shots
 
-        # Static config from GET /backends/{id}; {} offline. Skipped when
-        # num_qubits is given explicitly (test mocks) to stay network-free.
+        # Resolve static config (qubits, gates, capabilities) from one
+        # GET /backends/{id}. An explicit num_qubits (e.g. MockBackend in
+        # tests) bypasses the network; otherwise an unreachable API yields {}
+        # and we fall back to a small default qubit count.
+        self._config: dict = {}
         if num_qubits is None:
             creds = self._provider.credentials
-            self._config = get_backend_config(
-                name, creds.get("token"), creds.get("url")
-            )
-            num_qubits = int(self._config.get("qubits", 4))
-        else:
-            self._config = {}
+            self._config = get_backend_config(name, creds["token"], creds["url"])
+            num_qubits = int(self._config.get("qubits", _DEFAULT_NUM_QUBITS))
         self._num_qubits: int = num_qubits
 
-        # Target/coupling map resolved lazily on first access (keeps __init__
-        # network-free); _cached_noise_model drives native-sim target rebuilds.
+        # Target and coupling map are resolved lazily on first access, keeping
+        # construction network-free.
         self._target: Target | None = None
         self._coupling_map: CouplingMap | None = None
         self._restricted_coupling: bool = False
+        # noise_model the native-simulator Target was last built for, so it
+        # gets rebuilt when the user switches noise models.
         self._cached_noise_model: str | None = None
 
         # Apply initial options if any
@@ -158,14 +168,15 @@ class IonQBackend(Backend):
 
     @property
     def target(self) -> Target | None:
-        # Native-sim target depends on the noise model; rebuild on change.
-        if self._simulator and self._gateset == "native":
-            current_noise_model = getattr(self.options, "noise_model", "ideal")
-            if self._target is None or self._cached_noise_model != current_noise_model:
-                self._target = self._make_target()
-                self._cached_noise_model = current_noise_model
-        elif self._target is None:
+        # A native-gateset simulator's Target depends on the active noise model
+        # (it selects the 2q gate), so rebuild it when that changes.
+        native_sim = self._simulator and self._gateset == "native"
+        current_noise_model = getattr(self.options, "noise_model", "ideal")
+        if self._target is None or (
+            native_sim and self._cached_noise_model != current_noise_model
+        ):
             self._target = self._make_target()
+            self._cached_noise_model = current_noise_model
         return self._target
 
     @property
@@ -179,23 +190,23 @@ class IonQBackend(Backend):
 
     @property
     def supported_gates(self) -> list[str]:
-        """QIS gate names the backend accepts (API ``supported_gates``)."""
+        """QIS gate names the API accepts; empty if the config was unavailable."""
         return list(self._config.get("supported_gates") or [])
 
     @property
     def supported_native_gates(self) -> list[str]:
-        """Native gate names the backend accepts (API ``supported_native_gates``)."""
+        """Native gate names the API accepts; empty if the config was unavailable."""
         return list(self._config.get("supported_native_gates") or [])
 
     @property
     def supported_error_mitigations(self) -> list[str]:
-        """Error-mitigation methods the backend supports (API field)."""
+        """Supported error-mitigation techniques; empty if the config was unavailable."""
         return list(self._config.get("supported_error_mitigations") or [])
 
     @property
     def coupling_map(self) -> CouplingMap:
         """Qubit connectivity from the characterization, else all-to-all."""
-        return self._resolve_coupling_map()
+        return self._get_coupling_map()
 
     @property
     def max_circuits(self) -> int | None:
@@ -237,9 +248,8 @@ class IonQBackend(Backend):
 
     @property
     def _api_backend_name(self) -> str:
-        """Backend name used by the IonQ API (e.g., `qpu.forte-1`)."""
-        # QPU names are `ionq_qpu.*` locally; API expects `qpu.*`
-        return self.name.replace("ionq_qpu", "qpu")
+        """Backend name used by the IonQ API (e.g. ``qpu.forte-1``)."""
+        return api_backend_id(self.name)
 
     def run(
         self, run_input: QuantumCircuit | Sequence[QuantumCircuit], **options
@@ -315,8 +325,12 @@ class IonQBackend(Backend):
         return hash((self.name, self._gateset))
 
     def _fetch_connectivity(self) -> list[tuple[int, int]] | None:
-        """Two-qubit pairs from the characterization; ``None`` (-> all-to-all)
-        for simulators or any failed/empty lookup."""
+        """Connectivity pairs (valid two-qubit pairs) from the characterization.
+
+        Returns ``None`` -- meaning all-to-all -- for simulators, a backend
+        that reports no connectivity, or any failed lookup (offline, missing
+        credentials, unknown system).
+        """
         if self._simulator:
             return None
         try:
@@ -332,27 +346,36 @@ class IonQBackend(Backend):
             return cal.connectivity
         return None
 
-    def _resolve_coupling_map(self) -> CouplingMap:
-        """Cached coupling map: a genuine connectivity subset is restricted
-        (symmetrized); a complete or missing graph stays implicit all-to-all."""
+    def _get_coupling_map(self) -> CouplingMap:
+        """Backend coupling map, resolved once and cached.
+
+        Uses the characterization's connectivity when it describes a genuine
+        *subset* of pairs (e.g. Tempo's multi-parcel layout), symmetrizing each
+        pair since IonQ two-qubit gates are direction-agnostic. A complete or
+        missing graph -- what IonQ's all-to-all systems report -- resolves to
+        an implicit all-to-all map instead.
+        """
         if self._coupling_map is not None:
             return self._coupling_map
 
         n = self._num_qubits
         pairs = self._fetch_connectivity()
         if pairs:
-            edges: set[tuple[int, int]] = set()
-            for left, right in pairs:
-                left, right = int(left), int(right)
-                for src, dst in ((left, right), (right, left)):
-                    if src != dst and 0 <= src < n and 0 <= dst < n:
-                        edges.add((src, dst))
-            # n*(n-1) directed edges == complete graph -> treat as all-to-all.
+            # Collect into a set (symmetrize + dedupe + bounds-check) so we can
+            # compare the edge count against a complete graph below.
+            edges = {
+                (src, dst)
+                for left, right in pairs
+                for src, dst in ((int(left), int(right)), (int(right), int(left)))
+                if src != dst and 0 <= src < n and 0 <= dst < n
+            }
+            # n*(n-1) directed edges == a complete graph (all-to-all); only a
+            # strict subset is treated as a restricted topology.
             if edges and len(edges) < n * (n - 1):
                 cmap = CouplingMap()
-                for qubit in range(n):
+                for qubit in range(n):  # keep isolated qubits as nodes
                     cmap.add_physical_qubit(qubit)
-                for src, dst in sorted(edges):
+                for src, dst in sorted(edges):  # sorted for deterministic order
                     cmap.add_edge(src, dst)
                 self._coupling_map = cmap
                 self._restricted_coupling = True
@@ -363,22 +386,23 @@ class IonQBackend(Backend):
         return self._coupling_map
 
     def _make_target(self) -> Target:
-        """Build a Target of QIS or native gates, scoping 2q gates to the
-        coupling map on restricted topologies (else all-to-all)."""
+        """Build a Target of QIS or native gates, scoping 2q gates to the coupling
+        map on restricted topologies (else use all-to-all connectivity)."""
         tgt = Target(num_qubits=self._num_qubits)
 
-        self._resolve_coupling_map()
+        self._get_coupling_map()
         two_q_props = (
             {edge: None for edge in self._coupling_map.get_edges()}
             if self._restricted_coupling and self._coupling_map is not None
             else None
         )
 
-        def add(instruction) -> None:
+        def add_gate(instruction, name: str | None = None) -> None:
+            """Add a gate, scoping 2q gates to valid pairs on restricted topologies."""
             if two_q_props is not None and getattr(instruction, "num_qubits", 0) == 2:
-                tgt.add_instruction(instruction, dict(two_q_props))
+                tgt.add_instruction(instruction, dict(two_q_props), name=name)
             else:
-                tgt.add_instruction(instruction)
+                tgt.add_instruction(instruction, name=name)
 
         if self._gateset == "qis":
             theta = Parameter("θ")
@@ -416,29 +440,29 @@ class IonQBackend(Backend):
                 RYYGate(theta),
                 RZZGate(theta),
             ):
-                add(gate)
+                add_gate(gate)
 
-            tgt.add_instruction(MCXGate, name="mcx")
-            tgt.add_instruction(MCPhaseGate, name="mcphase")
-            tgt.add_instruction(PauliEvolutionGate, name="PauliEvolution")
+            add_gate(MCXGate, name="mcx")
+            add_gate(MCPhaseGate, name="mcphase")
+            add_gate(PauliEvolutionGate, name="PauliEvolution")
 
         else:
             # 1q native
             phi = Parameter("φ")
             for gate in (GPIGate(phi), GPI2Gate(phi)):
-                add(gate)
+                add_gate(gate)
 
             # 2q native: ms (Aria) or zz (Forte/Tempo), per the API config.
             if self._two_q_native_gate() == "zz":
                 theta = Parameter("θ")
-                add(ZZGate(theta))
+                add_gate(ZZGate(theta))
             else:
                 phi0, phi1, theta = Parameter("φ0"), Parameter("φ1"), Parameter("θ")
-                add(MSGate(phi0, phi1, theta))
+                add_gate(MSGate(phi0, phi1, theta))
 
         # Always allow measure/reset
         for cls in (Measure, Reset):
-            tgt.add_instruction(cls())
+            add_gate(cls())
 
         return tgt
 

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -115,11 +115,8 @@ class IonQBackend(Backend):
         self._max_experiments: int | None = max_experiments
         self._max_shots: int | None = max_shots
 
-        # Static backend configuration (qubits, supported/native gates, error
-        # mitigations) from a single GET /backends/{id} via the provider's
-        # credentials. ``{}`` when offline -> callers fall back to defaults.
-        # Skipped when ``num_qubits`` is given explicitly (e.g. test mocks) so
-        # construction stays network-free.
+        # Static config from GET /backends/{id}; {} offline. Skipped when
+        # num_qubits is given explicitly (test mocks) to stay network-free.
         if num_qubits is None:
             creds = self._provider.credentials
             self._config = get_backend_config(
@@ -130,14 +127,11 @@ class IonQBackend(Backend):
             self._config = {}
         self._num_qubits: int = num_qubits
 
-        # Target & coupling map are resolved lazily (on first ``.target`` /
-        # ``.coupling_map`` access) so backend construction stays network-free.
-        # QPU connectivity is then read from the latest characterization and
-        # cached; simulators and any fetch failure fall back to all-to-all.
+        # Target/coupling map resolved lazily on first access (keeps __init__
+        # network-free); _cached_noise_model drives native-sim target rebuilds.
         self._target: Target | None = None
         self._coupling_map: CouplingMap | None = None
         self._restricted_coupling: bool = False
-        # Track noise_model for native simulator target caching
         self._cached_noise_model: str | None = None
 
         # Apply initial options if any
@@ -164,8 +158,7 @@ class IonQBackend(Backend):
 
     @property
     def target(self) -> Target | None:
-        # The native simulator target depends on the selected noise model (it
-        # picks the matching 2q gate), so rebuild it when that changes.
+        # Native-sim target depends on the noise model; rebuild on change.
         if self._simulator and self._gateset == "native":
             current_noise_model = getattr(self.options, "noise_model", "ideal")
             if self._target is None or self._cached_noise_model != current_noise_model:
@@ -201,14 +194,7 @@ class IonQBackend(Backend):
 
     @property
     def coupling_map(self) -> CouplingMap:
-        """Physical qubit connectivity.
-
-        Built from the latest characterization's ``connectivity`` (the set of
-        valid two-qubit pairs) for QPUs that report a restricted topology --
-        e.g. Tempo's multi-parcel layout. Falls back to all-to-all for
-        simulators, the generic ``ionq_qpu`` meta-backend, and IonQ's current
-        fully-connected trapped-ion systems (Aria, Forte).
-        """
+        """Qubit connectivity from the characterization, else all-to-all."""
         return self._resolve_coupling_map()
 
     @property
@@ -329,13 +315,8 @@ class IonQBackend(Backend):
         return hash((self.name, self._gateset))
 
     def _fetch_connectivity(self) -> list[tuple[int, int]] | None:
-        """Valid two-qubit pairs from the latest characterization.
-
-        Returns ``None`` for simulators, when the backend reports no
-        connectivity, or when the lookup fails for any reason (offline,
-        missing credentials, unknown system) -- callers then default to
-        all-to-all.
-        """
+        """Two-qubit pairs from the characterization; ``None`` (-> all-to-all)
+        for simulators or any failed/empty lookup."""
         if self._simulator:
             return None
         try:
@@ -352,17 +333,8 @@ class IonQBackend(Backend):
         return None
 
     def _resolve_coupling_map(self) -> CouplingMap:
-        """Coupling map for this backend, cached after first resolution.
-
-        Restricted topologies come from the characterization's ``connectivity``
-        (a list of undirected ``[i, j]`` pairs). IonQ two-qubit gates are
-        symmetric, so each pair is added in both directions; pairs outside
-        ``num_qubits`` are ignored defensively. A *complete* graph (which IonQ's
-        all-to-all systems report in full) and anything missing resolve to an
-        all-to-all map left implicit in the Target -- cheaper to build and
-        identical for routing. Only a genuine subset marks the Target
-        restricted (e.g. Tempo's multi-parcel layout).
-        """
+        """Cached coupling map: a genuine connectivity subset is restricted
+        (symmetrized); a complete or missing graph stays implicit all-to-all."""
         if self._coupling_map is not None:
             return self._coupling_map
 
@@ -391,16 +363,10 @@ class IonQBackend(Backend):
         return self._coupling_map
 
     def _make_target(self) -> Target:
-        """Build a Target exposing either QIS or IonQ-native gates.
-
-        Two-qubit gates are constrained to the backend's coupling map when the
-        characterization reports a restricted topology; otherwise they are
-        added as globally available (all-to-all), matching IonQ's fully
-        connected trapped-ion systems.
-        """
+        """Build a Target of QIS or native gates, scoping 2q gates to the
+        coupling map on restricted topologies (else all-to-all)."""
         tgt = Target(num_qubits=self._num_qubits)
 
-        # Resolve connectivity first so 2q gates can be scoped to valid pairs.
         self._resolve_coupling_map()
         two_q_props = (
             {edge: None for edge in self._coupling_map.get_edges()}
@@ -409,7 +375,6 @@ class IonQBackend(Backend):
         )
 
         def add(instruction) -> None:
-            """Add a gate, scoping 2q gates to the coupling map when restricted."""
             if two_q_props is not None and getattr(instruction, "num_qubits", 0) == 2:
                 tgt.add_instruction(instruction, dict(two_q_props))
             else:
@@ -463,8 +428,7 @@ class IonQBackend(Backend):
             for gate in (GPIGate(phi), GPI2Gate(phi)):
                 add(gate)
 
-            # 2q native: ms (Aria) or zz (Forte/Tempo), from the API's
-            # supported_native_gates -- see _two_q_native_gate().
+            # 2q native: ms (Aria) or zz (Forte/Tempo), per the API config.
             if self._two_q_native_gate() == "zz":
                 theta = Parameter("θ")
                 add(ZZGate(theta))
@@ -479,13 +443,8 @@ class IonQBackend(Backend):
         return tgt
 
     def _two_q_native_gate(self) -> Literal["ms", "zz"]:
-        """The device's native two-qubit gate, from ``supported_native_gates``.
-
-        QPUs use their own config. The simulator follows its active
-        ``noise_model`` (which names the emulated device); with no/``ideal``
-        noise model it has no real device, so it defaults to ``"ms"`` -- also
-        the fallback whenever the API is unreachable.
-        """
+        """Native 2q gate from ``supported_native_gates`` (the simulator follows
+        its noise model); defaults to ``"ms"`` for ideal-sim and offline."""
         config = self._config
         if self._simulator:
             noise_model = getattr(self.options, "noise_model", None)

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -121,9 +121,9 @@ class IonQBackend(Backend):
         self._max_shots: int | None = max_shots
 
         # Static config (qubits, gates, capabilities) comes from the provider's
-        # cached /backends catalog. An explicit num_qubits (e.g. MockBackend in
-        # tests) bypasses it; otherwise a missing entry yields {} and we fall
-        # back to a small default qubit count.
+        # cached /backends catalog. An explicit num_qubits pins the caller's
+        # own config and bypasses the catalog; otherwise a missing entry
+        # yields {} and we fall back to a small default qubit count.
         self._config: dict = {}
         if num_qubits is None:
             self._config = self._provider.backend_config(name)
@@ -165,7 +165,7 @@ class IonQBackend(Backend):
 
     @property
     def target(self) -> Target | None:
-        # A native-gateset simulator's Target depends on the active noise model
+        # A native-gateset simulator's target depends on the active noise model
         # (it selects the 2q gate), so rebuild it when that changes.
         native_sim = self._simulator and self._gateset == "native"
         current_noise_model = getattr(self.options, "noise_model", "ideal")

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -71,12 +71,7 @@ from qiskit.transpiler import Target, CouplingMap
 
 from qiskit_ionq.ionq_gates import GPIGate, GPI2Gate, MSGate, ZZGate
 from . import ionq_equivalence_library, ionq_job, ionq_client, exceptions
-from .helpers import (
-    GATESET_MAP,
-    api_backend_id,
-    get_backend_config,
-    warn_bad_transpile_level,
-)
+from .helpers import GATESET_MAP, api_backend_id, warn_bad_transpile_level
 from .ionq_client import Characterization
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -124,14 +119,13 @@ class IonQBackend(Backend):
         self._max_experiments: int | None = max_experiments
         self._max_shots: int | None = max_shots
 
-        # Resolve static config (qubits, gates, capabilities) from one
-        # GET /backends/{id}. An explicit num_qubits (e.g. MockBackend in
-        # tests) bypasses the network; otherwise an unreachable API yields {}
-        # and we fall back to a small default qubit count.
+        # Static config (qubits, gates, capabilities) comes from the provider's
+        # cached /backends catalog. An explicit num_qubits (e.g. MockBackend in
+        # tests) bypasses it; otherwise a missing entry yields {} and we fall
+        # back to a small default qubit count.
         self._config: dict = {}
         if num_qubits is None:
-            creds = self._provider.credentials
-            self._config = get_backend_config(name, creds["token"], creds["url"])
+            self._config = self._provider.backend_config(name)
             num_qubits = int(self._config.get("qubits", _DEFAULT_NUM_QUBITS))
         self._num_qubits: int = num_qubits
 
@@ -474,10 +468,7 @@ class IonQBackend(Backend):
             noise_model = getattr(self.options, "noise_model", None)
             if not noise_model or noise_model == "ideal":
                 return "ms"
-            creds = self._provider.credentials
-            config = get_backend_config(
-                noise_model, creds.get("token"), creds.get("url")
-            )
+            config = self._provider.backend_config(noise_model)
         return "zz" if "zz" in (config.get("supported_native_gates") or []) else "ms"
 
     @staticmethod

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -77,8 +77,9 @@ from .ionq_client import Characterization
 if TYPE_CHECKING:  # pragma: no cover
     from .ionq_provider import IonQProvider
 
-# Fallback qubit count when GET /backends/{id} is unreachable (offline), so a
-# Target can still be built; real counts come from the API.
+# Fallback qubit count when the /backends catalog has no config for a backend
+# (offline, unknown id), so a Target can still be built; real counts come from
+# the API.
 _DEFAULT_NUM_QUBITS = 4
 
 

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -402,7 +402,7 @@ class IonQSimulatorBackend(IonQBackend):
 
 
 class IonQQPUBackend(IonQBackend):
-    """IonQ trapped-ion hardware back-ends (Aria: MS; Forte: ZZ)."""
+    """IonQ trapped-ion hardware back-ends (Aria: MS; Forte/Tempo: ZZ)."""
 
     def __init__(
         self,

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -182,20 +182,33 @@ class IonQBackend(Backend):
         """Return the basis gates for this backend."""
         return self._basis_gates
 
+    def _config_list(self, key: str) -> list[str]:
+        """Read a list-valued key from the API config, warning when the config
+        is unavailable so an empty result is distinguishable from "none"."""
+        if not self._config:
+            warnings.warn(
+                f"No API config available for backend {self.name!r}; "
+                f"{key} is unknown (returning an empty list)."
+            )
+        return list(self._config.get(key) or [])
+
     @property
     def supported_gates(self) -> list[str]:
-        """QIS gate names the API accepts; empty if the config was unavailable."""
-        return list(self._config.get("supported_gates") or [])
+        """QIS gate names the API accepts; empty (with a warning) if the config
+        was unavailable."""
+        return self._config_list("supported_gates")
 
     @property
     def supported_native_gates(self) -> list[str]:
-        """Native gate names the API accepts; empty if the config was unavailable."""
-        return list(self._config.get("supported_native_gates") or [])
+        """Native gate names the API accepts; empty (with a warning) if the config
+        was unavailable."""
+        return self._config_list("supported_native_gates")
 
     @property
     def supported_error_mitigations(self) -> list[str]:
-        """Supported error-mitigation techniques; empty if the config was unavailable."""
-        return list(self._config.get("supported_error_mitigations") or [])
+        """Supported error-mitigation techniques; empty (with a warning) if the
+        config was unavailable."""
+        return self._config_list("supported_error_mitigations")
 
     @property
     def coupling_map(self) -> CouplingMap:

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -71,7 +71,7 @@ from qiskit.transpiler import Target, CouplingMap
 
 from qiskit_ionq.ionq_gates import GPIGate, GPI2Gate, MSGate, ZZGate
 from . import ionq_equivalence_library, ionq_job, ionq_client, exceptions
-from .helpers import GATESET_MAP, get_n_qubits, native_2q_gate, warn_bad_transpile_level
+from .helpers import GATESET_MAP, get_backend_config, warn_bad_transpile_level
 from .ionq_client import Characterization
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -90,8 +90,8 @@ class IonQBackend(Backend):
         name: str,
         description: str,
         gateset: Literal["qis", "native"],
-        num_qubits: int,
         simulator: bool,
+        num_qubits: int | None = None,
         backend_version: str = "0.0.1",
         max_shots: int | None = None,
         max_experiments: int | None = None,
@@ -111,13 +111,32 @@ class IonQBackend(Backend):
         # Immutable facts
         self._gateset: Literal["qis", "native"] = gateset
         self._basis_gates: Sequence[str] = tuple(GATESET_MAP[gateset])
-        self._num_qubits: int = num_qubits
         self._simulator: bool = simulator
         self._max_experiments: int | None = max_experiments
         self._max_shots: int | None = max_shots
 
-        # Target (basis & connectivity)
-        self._target = self._make_target()
+        # Static backend configuration (qubits, supported/native gates, error
+        # mitigations) from a single GET /backends/{id} via the provider's
+        # credentials. ``{}`` when offline -> callers fall back to defaults.
+        # Skipped when ``num_qubits`` is given explicitly (e.g. test mocks) so
+        # construction stays network-free.
+        if num_qubits is None:
+            creds = self._provider.credentials
+            self._config = get_backend_config(
+                name, creds.get("token"), creds.get("url")
+            )
+            num_qubits = int(self._config.get("qubits", 4))
+        else:
+            self._config = {}
+        self._num_qubits: int = num_qubits
+
+        # Target & coupling map are resolved lazily (on first ``.target`` /
+        # ``.coupling_map`` access) so backend construction stays network-free.
+        # QPU connectivity is then read from the latest characterization and
+        # cached; simulators and any fetch failure fall back to all-to-all.
+        self._target: Target | None = None
+        self._coupling_map: CouplingMap | None = None
+        self._restricted_coupling: bool = False
         # Track noise_model for native simulator target caching
         self._cached_noise_model: str | None = None
 
@@ -145,11 +164,15 @@ class IonQBackend(Backend):
 
     @property
     def target(self) -> Target | None:
+        # The native simulator target depends on the selected noise model (it
+        # picks the matching 2q gate), so rebuild it when that changes.
         if self._simulator and self._gateset == "native":
             current_noise_model = getattr(self.options, "noise_model", "ideal")
-            if self._cached_noise_model != current_noise_model:
+            if self._target is None or self._cached_noise_model != current_noise_model:
                 self._target = self._make_target()
                 self._cached_noise_model = current_noise_model
+        elif self._target is None:
+            self._target = self._make_target()
         return self._target
 
     @property
@@ -162,9 +185,31 @@ class IonQBackend(Backend):
         return self._basis_gates
 
     @property
+    def supported_gates(self) -> list[str]:
+        """QIS gate names the backend accepts (API ``supported_gates``)."""
+        return list(self._config.get("supported_gates") or [])
+
+    @property
+    def supported_native_gates(self) -> list[str]:
+        """Native gate names the backend accepts (API ``supported_native_gates``)."""
+        return list(self._config.get("supported_native_gates") or [])
+
+    @property
+    def supported_error_mitigations(self) -> list[str]:
+        """Error-mitigation methods the backend supports (API field)."""
+        return list(self._config.get("supported_error_mitigations") or [])
+
+    @property
     def coupling_map(self) -> CouplingMap:
-        """IonQ hardware is fully connected."""
-        return CouplingMap.from_full(self._num_qubits)
+        """Physical qubit connectivity.
+
+        Built from the latest characterization's ``connectivity`` (the set of
+        valid two-qubit pairs) for QPUs that report a restricted topology --
+        e.g. Tempo's multi-parcel layout. Falls back to all-to-all for
+        simulators, the generic ``ionq_qpu`` meta-backend, and IonQ's current
+        fully-connected trapped-ion systems (Aria, Forte).
+        """
+        return self._resolve_coupling_map()
 
     @property
     def max_circuits(self) -> int | None:
@@ -283,9 +328,92 @@ class IonQBackend(Backend):
     def __hash__(self):
         return hash((self.name, self._gateset))
 
+    def _fetch_connectivity(self) -> list[tuple[int, int]] | None:
+        """Valid two-qubit pairs from the latest characterization.
+
+        Returns ``None`` for simulators, when the backend reports no
+        connectivity, or when the lookup fails for any reason (offline,
+        missing credentials, unknown system) -- callers then default to
+        all-to-all.
+        """
+        if self._simulator:
+            return None
+        try:
+            cal = self.calibration()
+        except Exception as exc:  # pylint: disable=broad-except
+            warnings.warn(
+                f"Could not fetch connectivity for {self.name}: {exc}. "
+                "Falling back to all-to-all coupling.",
+                stacklevel=2,
+            )
+            return None
+        if cal is not None and cal.connectivity:
+            return cal.connectivity
+        return None
+
+    def _resolve_coupling_map(self) -> CouplingMap:
+        """Coupling map for this backend, cached after first resolution.
+
+        Restricted topologies come from the characterization's ``connectivity``
+        (a list of undirected ``[i, j]`` pairs). IonQ two-qubit gates are
+        symmetric, so each pair is added in both directions; pairs outside
+        ``num_qubits`` are ignored defensively. A *complete* graph (which IonQ's
+        all-to-all systems report in full) and anything missing resolve to an
+        all-to-all map left implicit in the Target -- cheaper to build and
+        identical for routing. Only a genuine subset marks the Target
+        restricted (e.g. Tempo's multi-parcel layout).
+        """
+        if self._coupling_map is not None:
+            return self._coupling_map
+
+        n = self._num_qubits
+        pairs = self._fetch_connectivity()
+        if pairs:
+            edges: set[tuple[int, int]] = set()
+            for left, right in pairs:
+                left, right = int(left), int(right)
+                for src, dst in ((left, right), (right, left)):
+                    if src != dst and 0 <= src < n and 0 <= dst < n:
+                        edges.add((src, dst))
+            # n*(n-1) directed edges == complete graph -> treat as all-to-all.
+            if edges and len(edges) < n * (n - 1):
+                cmap = CouplingMap()
+                for qubit in range(n):
+                    cmap.add_physical_qubit(qubit)
+                for src, dst in sorted(edges):
+                    cmap.add_edge(src, dst)
+                self._coupling_map = cmap
+                self._restricted_coupling = True
+                return self._coupling_map
+
+        self._coupling_map = CouplingMap.from_full(n)
+        self._restricted_coupling = False
+        return self._coupling_map
+
     def _make_target(self) -> Target:
-        """Build a Target exposing either QIS or IonQ-native gates."""
+        """Build a Target exposing either QIS or IonQ-native gates.
+
+        Two-qubit gates are constrained to the backend's coupling map when the
+        characterization reports a restricted topology; otherwise they are
+        added as globally available (all-to-all), matching IonQ's fully
+        connected trapped-ion systems.
+        """
         tgt = Target(num_qubits=self._num_qubits)
+
+        # Resolve connectivity first so 2q gates can be scoped to valid pairs.
+        self._resolve_coupling_map()
+        two_q_props = (
+            {edge: None for edge in self._coupling_map.get_edges()}
+            if self._restricted_coupling and self._coupling_map is not None
+            else None
+        )
+
+        def add(instruction) -> None:
+            """Add a gate, scoping 2q gates to the coupling map when restricted."""
+            if two_q_props is not None and getattr(instruction, "num_qubits", 0) == 2:
+                tgt.add_instruction(instruction, dict(two_q_props))
+            else:
+                tgt.add_instruction(instruction)
 
         if self._gateset == "qis":
             theta = Parameter("θ")
@@ -323,7 +451,7 @@ class IonQBackend(Backend):
                 RYYGate(theta),
                 RZZGate(theta),
             ):
-                tgt.add_instruction(gate)
+                add(gate)
 
             tgt.add_instruction(MCXGate, name="mcx")
             tgt.add_instruction(MCPhaseGate, name="mcphase")
@@ -333,26 +461,41 @@ class IonQBackend(Backend):
             # 1q native
             phi = Parameter("φ")
             for gate in (GPIGate(phi), GPI2Gate(phi)):
-                tgt.add_instruction(gate)
+                add(gate)
 
-            # 2q native: per family (see helpers.NATIVE_2Q_BY_FAMILY).
-            gate = (
-                native_2q_gate(self.name)
-                or native_2q_gate(getattr(self.options, "noise_model", None))
-                or "ms"
-            )
-            if gate == "zz":
+            # 2q native: ms (Aria) or zz (Forte/Tempo), from the API's
+            # supported_native_gates -- see _two_q_native_gate().
+            if self._two_q_native_gate() == "zz":
                 theta = Parameter("θ")
-                tgt.add_instruction(ZZGate(theta))
+                add(ZZGate(theta))
             else:
                 phi0, phi1, theta = Parameter("φ0"), Parameter("φ1"), Parameter("θ")
-                tgt.add_instruction(MSGate(phi0, phi1, theta))
+                add(MSGate(phi0, phi1, theta))
 
         # Always allow measure/reset
         for cls in (Measure, Reset):
             tgt.add_instruction(cls())
 
         return tgt
+
+    def _two_q_native_gate(self) -> Literal["ms", "zz"]:
+        """The device's native two-qubit gate, from ``supported_native_gates``.
+
+        QPUs use their own config. The simulator follows its active
+        ``noise_model`` (which names the emulated device); with no/``ideal``
+        noise model it has no real device, so it defaults to ``"ms"`` -- also
+        the fallback whenever the API is unreachable.
+        """
+        config = self._config
+        if self._simulator:
+            noise_model = getattr(self.options, "noise_model", None)
+            if not noise_model or noise_model == "ideal":
+                return "ms"
+            creds = self._provider.credentials
+            config = get_backend_config(
+                noise_model, creds.get("token"), creds.get("url")
+            )
+        return "zz" if "zz" in (config.get("supported_native_gates") or []) else "ms"
 
     @staticmethod
     def _has_measurements(circ: QuantumCircuit) -> bool:
@@ -389,7 +532,6 @@ class IonQSimulatorBackend(IonQBackend):
             name=backend_name,
             description="IonQ cloud simulator",
             gateset=gateset,
-            num_qubits=get_n_qubits(name),
             simulator=True,
             max_shots=1,
             max_experiments=None,
@@ -416,7 +558,6 @@ class IonQQPUBackend(IonQBackend):
             name=name,
             description="IonQ trapped-ion QPU",
             gateset=gateset,
-            num_qubits=get_n_qubits(name),
             simulator=False,
             max_shots=10_000,
             max_experiments=None,

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -338,6 +338,8 @@ class IonQClient:
         try:
             return json.loads(res.text, object_pairs_hook=OrderedDict)
         except ValueError:
+            # Content type was missing or unrecognized and the body isn't
+            # JSON; return the raw text rather than raising.
             return res.text
 
     def estimate_job(

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -310,18 +310,25 @@ class IonQClient:
     ) -> dict | list | str | bytes:
         """GET a result artifact by id (``/jobs/{id}/artifacts/{aid}``).
 
-        JSON artifacts decode to order-preserving objects; binary ones (the
-        ``ionq.mir.v1`` compiled circuit, ``application/octet-stream``) return
-        as raw ``bytes``.
+        Decodes by content type: JSON (``ionq.native.v1``, ``ionq.ore.v*``,
+        result artifacts) to order-preserving objects, text (``ionq.qasm3.v1``
+        compiled circuit, ``text/plain``) to ``str``, and binary
+        (``ionq.mir.v1``, ``application/octet-stream``) to raw ``bytes``.
         """
         req_path = self.make_path("jobs", job_id, "artifacts", artifact_id)
         res = self.get_with_retry(
             req_path, headers=self.api_headers, params=extra_query_params or None
         )
         exceptions.IonQAPIError.raise_for_status(res)
-        if "octet-stream" in res.headers.get("Content-Type", "").lower():
+        content_type = res.headers.get("Content-Type", "").lower()
+        if "octet-stream" in content_type:
             return res.content
-        return json.loads(res.text, object_pairs_hook=OrderedDict)
+        if content_type.startswith("text/"):
+            return res.text
+        try:
+            return json.loads(res.text, object_pairs_hook=OrderedDict)
+        except ValueError:
+            return res.text
 
     def estimate_job(
         self,

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -731,9 +731,9 @@ class IonQJob(JobV1):
         # Zero-padded binary so get_counts() splits by creg_sizes.
         width = header.get("memory_slots") or len(clbit_labels)
 
-        # Registers absent from the artifact fold as all-zeros; warn so a
-        # server-side omission (e.g. compiler-elided measurements) is not
-        # mistaken for a genuine all-zero outcome.
+        # Missing registers default to all-zeros. Emit a warning because an
+        # omitted register (e.g. compiler-elided measurements) is not the same
+        # as a register that was actually measured and found to be all zeros.
         declared = {label[0] for label in clbit_labels}
         first = shots[0] if shots and isinstance(shots[0], dict) else {}
         missing = declared - set(first.get("registers") or {})

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -701,6 +701,20 @@ class IonQJob(JobV1):
         # Zero-padded binary so get_counts() splits by creg_sizes.
         width = header.get("memory_slots") or len(clbit_labels)
 
+        # Registers absent from the artifact fold as all-zeros; warn so a
+        # server-side omission (e.g. compiler-elided measurements) is not
+        # mistaken for a genuine all-zero outcome.
+        declared = {label[0] for label in clbit_labels}
+        first = shots[0] if shots and isinstance(shots[0], dict) else {}
+        missing = declared - set(first.get("registers") or {})
+        if shots and missing:
+            warnings.warn(
+                f"Register(s) {sorted(missing)} declared by the circuit are "
+                "missing from the job's shots artifact; their bits will read "
+                "as 0 in counts/memory.",
+                UserWarning,
+            )
+
         counts: dict[str, int] = {}
         memory: list[str] = []
         for shot in shots:

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -589,8 +589,8 @@ class IonQJob(JobV1):
             failure = response.get("failure") or {}
             raise exceptions.IonQJobFailureError(
                 f"Unable to retrieve result for job {self._job_id}. "
-                f'Failure from IonQ API "{failure.get("code","")}: '
-                f'{failure.get("error","")}"'
+                f'Failure from IonQ API "{failure.get("code", "")}: '
+                f'{failure.get("error", "")}"'
             )
 
         if self._status == jobstatus.JobStatus.CANCELLED:
@@ -718,7 +718,8 @@ class IonQJob(JobV1):
     def _format_result_qasm3(self, shots: list):
         """Build a Result from per-register shots, folding the declared
         registers via the header's ``clbit_labels``. ``output_all``
-        (system-added) is excluded.
+        (system-added) is excluded, as are shots tagged with nonzero
+        ``leakage_bits``.
         """
         backend = self.backend()
         success = self._status == jobstatus.JobStatus.DONE
@@ -727,6 +728,14 @@ class IonQJob(JobV1):
         header = decoded if isinstance(decoded, dict) else {}
 
         shots = shots or []
+        # Shots with any leakage bit set are invalid readouts; the platform
+        # excludes them from histogram/probabilities/legacy shots, so exclude
+        # them here too or counts would sum past the requested shot count.
+        shots = [
+            shot
+            for shot in shots
+            if not (isinstance(shot, dict) and any(shot.get("leakage_bits") or []))
+        ]
         clbit_labels = header.get("clbit_labels") or []
         # Zero-padded binary so get_counts() splits by creg_sizes.
         width = header.get("memory_slots") or len(clbit_labels)

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -82,7 +82,9 @@ class IonQProvider:
         config = self._catalog.get(api_id)
         if config is None and self._catalog and api_id != "qpu":
             warnings.warn(
-                f"Backend {api_id!r} not in the IonQ catalog; using defaults."
+                f"Backend {api_id!r} not in the IonQ catalog; it will be "
+                "built with a fallback qubit count, and its supported gates "
+                "and error mitigations will be reported as unknown."
             )
         return config or {}
 

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -29,12 +29,13 @@
 from __future__ import annotations
 
 import logging
+import warnings
 
 from typing import Callable, Literal
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.providerutils import filter_backends
-from .helpers import resolve_credentials
+from .helpers import api_backend_id, get_backends, resolve_credentials
 
 from . import ionq_backend
 
@@ -62,12 +63,28 @@ class IonQProvider:
         super().__init__()
         self.custom_headers = custom_headers
         self.credentials = resolve_credentials(token, url)
+        # One GET /backends call serves every backend's static config.
+        self._catalog = get_backends(self.credentials["token"], self.credentials["url"])
         self.backends = BackendService(
             [
                 ionq_backend.IonQSimulatorBackend(self),
                 ionq_backend.IonQQPUBackend(self),
             ]
         )
+
+    def backend_config(self, name: str) -> dict:
+        """Static config for ``name`` from the cached ``/backends`` catalog.
+
+        Returns ``{}`` for the generic ``ionq_qpu`` template (no real device)
+        and warns for an unknown backend when the catalog is populated.
+        """
+        api_id = api_backend_id(name)
+        config = self._catalog.get(api_id)
+        if config is None and self._catalog and api_id != "qpu":
+            warnings.warn(
+                f"Backend {api_id!r} not in the IonQ catalog; using defaults."
+            )
+        return config or {}
 
     def get_backend(
         self,

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -63,8 +63,8 @@ class IonQProvider:
         super().__init__()
         self.custom_headers = custom_headers
         self.credentials = resolve_credentials(token, url)
-        # One GET /backends call serves every backend's static config.
-        self._catalog = get_backends(self.credentials["token"], self.credentials["url"])
+        # /backends catalog, fetched lazily by get_backend_config.
+        self._catalog: dict[str, dict] | None = None
         self.backends = BackendService(
             [
                 ionq_backend.IonQSimulatorBackend(self),
@@ -72,12 +72,22 @@ class IonQProvider:
             ]
         )
 
-    def backend_config(self, name: str) -> dict:
-        """Static config for ``name`` from the cached ``/backends`` catalog.
+    def get_backend_config(self, name: str) -> dict:
+        """Static config for ``name`` from the ``GET /backends`` catalog.
 
-        Returns ``{}`` for the generic ``ionq_qpu`` template (no real device)
-        and warns for an unknown backend when the catalog is populated.
+        The catalog is fetched on first call and cached; a failed fetch warns
+        and caches ``{}`` so offline use still works. Returns ``{}`` for the
+        generic ``ionq_qpu`` template and warns for an unknown backend when
+        the catalog is populated.
         """
+        if self._catalog is None:
+            try:
+                self._catalog = get_backends(
+                    self.credentials["token"], self.credentials["url"]
+                )
+            except Exception as exception:  # pylint: disable=broad-except
+                warnings.warn(f"Failed to fetch backends catalog: {exception}.")
+                self._catalog = {}
         api_id = api_backend_id(name)
         config = self._catalog.get(api_id)
         if config is None and self._catalog and api_id != "qpu":
@@ -112,6 +122,8 @@ class IonQProvider:
         if not backends:
             raise QiskitBackendNotFoundError("No backend matches criteria.")
 
+        # Fetch (or reuse) the catalog now so an unknown name warns here.
+        self.get_backend_config(name)
         return backends[0].with_name(name, gateset=gateset)
 
 

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -94,7 +94,7 @@ class IonQProvider:
             warnings.warn(
                 f"Backend {api_id!r} not in the IonQ catalog; it will be "
                 "built with a fallback qubit count, and its supported gates "
-                "and error mitigations will be reported as unknown."
+                "and error mitigation options will be reported as unknown."
             )
         return config or {}
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,7 +35,7 @@ from requests_mock import Mocker, adapter as rm_adapter
 from qiskit_ionq import ionq_backend, ionq_job, ionq_provider
 from qiskit_ionq.helpers import compress_to_metadata_string
 
-# Offline stand-in for ``helpers.get_backend_config``. Native gatesets match
+# Offline stand-in for one backend's catalog entry. Native gatesets match
 # the real API per family; qubit counts stay small so backend-transpiled
 # statevector tests stay tractable (realistic counts: test_capabilities_from_api).
 _SAFE_QUBITS = 4
@@ -59,9 +59,15 @@ def fake_backend_config(name, token=None, url=None):  # pylint: disable=unused-a
 
 @pytest.fixture(autouse=True)
 def _offline_backend_data(monkeypatch):
-    """Network-free default: canned config and no connectivity (all-to-all).
-    Restricted-topology tests patch ``_fetch_connectivity`` per instance."""
-    monkeypatch.setattr(ionq_backend, "get_backend_config", fake_backend_config)
+    """Network-free default: empty catalog fetch, canned per-backend config, and
+    no connectivity (all-to-all). Restricted-topology tests patch
+    ``_fetch_connectivity`` per instance."""
+    monkeypatch.setattr(ionq_provider, "get_backends", lambda *a, **k: {})
+    monkeypatch.setattr(
+        ionq_provider.IonQProvider,
+        "backend_config",
+        lambda self, name: fake_backend_config(name),
+    )
     monkeypatch.setattr(
         ionq_backend.IonQBackend, "_fetch_connectivity", lambda self: None
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,6 +35,41 @@ from requests_mock import Mocker, adapter as rm_adapter
 from qiskit_ionq import ionq_backend, ionq_job, ionq_provider
 from qiskit_ionq.helpers import compress_to_metadata_string
 
+# Offline stand-in for ``helpers.get_backend_config``. Native gatesets mirror
+# the real API per family (Aria=MS, Forte/Tempo=ZZ); qubit counts are kept
+# small so backend-transpiled statevector tests stay tractable (matching the
+# old offline fallback). Realistic-count passthrough is covered separately by
+# ``test_backend_capabilities_from_api``.
+_SAFE_QUBITS = 4
+_FAMILY_2Q = {"aria": "ms", "forte": "zz", "tempo": "zz"}
+
+
+def fake_backend_config(name, token=None, url=None):  # pylint: disable=unused-argument
+    """Canned GET /backends/{id} payload, network-free."""
+    api_name = name.removeprefix("ionq_").removeprefix("qpu.")
+    two_q = next((g for fam, g in _FAMILY_2Q.items() if api_name.startswith(fam)), "zz")
+    config = {
+        "qubits": _SAFE_QUBITS,
+        "supported_gates": ["x", "y", "z", "h", "rx", "ry", "rz", "cnot", "swap"],
+        "supported_native_gates": ["gpi", "gpi2", two_q],
+        "supported_error_mitigations": ["Debias", "Sharpen"],
+    }
+    if api_name == "simulator":
+        config["noise_models"] = ["aria-1", "forte-1", "forte-enterprise-1", "ideal"]
+    return config
+
+
+@pytest.fixture(autouse=True)
+def _offline_backend_data(monkeypatch):
+    """Keep the suite network-free: serve canned backend config and report no
+    characterization connectivity (all-to-all) by default. Tests exercising a
+    restricted topology patch ``_fetch_connectivity`` on the instance.
+    """
+    monkeypatch.setattr(ionq_backend, "get_backend_config", fake_backend_config)
+    monkeypatch.setattr(
+        ionq_backend.IonQBackend, "_fetch_connectivity", lambda self: None
+    )
+
 
 def _def_results_template(job_id):
     """A template for the results field in a job response."""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,11 +35,9 @@ from requests_mock import Mocker, adapter as rm_adapter
 from qiskit_ionq import ionq_backend, ionq_job, ionq_provider
 from qiskit_ionq.helpers import compress_to_metadata_string
 
-# Offline stand-in for ``helpers.get_backend_config``. Native gatesets mirror
-# the real API per family (Aria=MS, Forte/Tempo=ZZ); qubit counts are kept
-# small so backend-transpiled statevector tests stay tractable (matching the
-# old offline fallback). Realistic-count passthrough is covered separately by
-# ``test_backend_capabilities_from_api``.
+# Offline stand-in for ``helpers.get_backend_config``. Native gatesets match
+# the real API per family; qubit counts stay small so backend-transpiled
+# statevector tests stay tractable (realistic counts: test_capabilities_from_api).
 _SAFE_QUBITS = 4
 _FAMILY_2Q = {"aria": "ms", "forte": "zz", "tempo": "zz"}
 
@@ -61,10 +59,8 @@ def fake_backend_config(name, token=None, url=None):  # pylint: disable=unused-a
 
 @pytest.fixture(autouse=True)
 def _offline_backend_data(monkeypatch):
-    """Keep the suite network-free: serve canned backend config and report no
-    characterization connectivity (all-to-all) by default. Tests exercising a
-    restricted topology patch ``_fetch_connectivity`` on the instance.
-    """
+    """Network-free default: canned config and no connectivity (all-to-all).
+    Restricted-topology tests patch ``_fetch_connectivity`` per instance."""
     monkeypatch.setattr(ionq_backend, "get_backend_config", fake_backend_config)
     monkeypatch.setattr(
         ionq_backend.IonQBackend, "_fetch_connectivity", lambda self: None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -69,7 +69,7 @@ def _offline_backend_data(monkeypatch):
     monkeypatch.setattr(ionq_provider, "get_backends", lambda *a, **k: {})
     monkeypatch.setattr(
         ionq_provider.IonQProvider,
-        "backend_config",
+        "get_backend_config",
         lambda self, name: fake_backend_config(name),
     )
     monkeypatch.setattr(

--- a/test/helpers/test_helpers.py
+++ b/test/helpers/test_helpers.py
@@ -30,7 +30,7 @@ import re
 from unittest.mock import patch, MagicMock
 import pytest
 from qiskit_ionq.ionq_client import IonQClient
-from qiskit_ionq.helpers import api_backend_id, get_backend_config, retry
+from qiskit_ionq.helpers import api_backend_id, get_backends, retry
 
 
 def test_user_agent_header():
@@ -68,45 +68,43 @@ def test_api_backend_id(name, expected):
     assert api_backend_id(name) == expected
 
 
-def test_backend_config_success():
-    """get_backend_config returns the backend payload and hits the right URL."""
-    with patch("requests.get") as mock_get:
-        payload = {
+def test_get_backends_success():
+    """get_backends returns the /backends catalog keyed by API id."""
+    catalog = [
+        {"backend": "simulator", "qubits": 29},
+        {
             "backend": "qpu.aria-1",
-            "status": "unavailable",
             "qubits": 25,
-            "supported_gates": ["x", "cnot"],
             "supported_native_gates": ["gpi", "gpi2", "ms"],
-            "supported_error_mitigations": ["Debias", "Sharpen"],
-        }
+        },
+        {
+            "backend": "qpu.tempo-1",
+            "qubits": 100,
+            "supported_native_gates": ["gpi", "gpi2", "zz"],
+        },
+    ]
+    with patch("requests.get") as mock_get:
         mock_response = MagicMock()
-        mock_response.json.return_value = payload
+        mock_response.json.return_value = catalog
         mock_response.raise_for_status.return_value = None
         mock_get.return_value = mock_response
 
-        result = get_backend_config("ionq_qpu.aria-1")
+        result = get_backends()
 
-        expected_url = "https://api.ionq.co/v0.4/backends/qpu.aria-1"
+        expected_url = "https://api.ionq.co/v0.4/backends"
         mock_get.assert_called()
         args, kwargs = mock_get.call_args
         actual_url = kwargs.get("url", args[0] if args else None)
         assert actual_url == expected_url
-        assert result == payload
-        assert result["qubits"] == 25
+        assert set(result) == {"simulator", "qpu.aria-1", "qpu.tempo-1"}
+        assert result["qpu.tempo-1"]["qubits"] == 100
 
 
-def test_backend_config_fallback():
-    """get_backend_config returns {} (with a warning) when the request fails."""
-    with patch("requests.get", side_effect=Exception("Network error")) as mock_get:
-        with pytest.warns(UserWarning, match="Failed to fetch config"):
-            result = get_backend_config("aria-1")
-
-        expected_url = "https://api.ionq.co/v0.4/backends/qpu.aria-1"
-        mock_get.assert_called()
-        args, kwargs = mock_get.call_args
-        actual_url = kwargs.get("url", args[0] if args else None)
-        assert actual_url == expected_url
-        assert result == {}
+def test_get_backends_fallback():
+    """get_backends returns {} (with a warning) when the request fails."""
+    with patch("requests.get", side_effect=Exception("Network error")):
+        with pytest.warns(UserWarning, match="Failed to fetch backends catalog"):
+            assert get_backends() == {}
 
 
 def test_retry():

--- a/test/helpers/test_helpers.py
+++ b/test/helpers/test_helpers.py
@@ -30,7 +30,7 @@ import re
 from unittest.mock import patch, MagicMock
 import pytest
 from qiskit_ionq.ionq_client import IonQClient
-from qiskit_ionq.helpers import get_backend_config, retry
+from qiskit_ionq.helpers import api_backend_id, get_backend_config, retry
 
 
 def test_user_agent_header():
@@ -50,6 +50,22 @@ def test_user_agent_header():
     # Checks whether there is at-least 3 version strings from qiskit-ionq, qiskit, python.
     has_all_version_strings = len(re.findall(r"\s*([\d.]+)", generated_user_agent)) >= 3
     assert all_user_agent_keywords_avail and has_all_version_strings
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("ionq_qpu.forte-1", "qpu.forte-1"),
+        ("forte-1", "qpu.forte-1"),
+        ("qpu.aria-1", "qpu.aria-1"),
+        ("ionq_simulator", "simulator"),
+        ("simulator", "simulator"),
+        ("ionq_qpu", "qpu"),
+    ],
+)
+def test_api_backend_id(name, expected):
+    """api_backend_id normalizes local backend names to their API id."""
+    assert api_backend_id(name) == expected
 
 
 def test_backend_config_success():

--- a/test/helpers/test_helpers.py
+++ b/test/helpers/test_helpers.py
@@ -28,8 +28,9 @@
 
 import re
 from unittest.mock import patch, MagicMock
+import pytest
 from qiskit_ionq.ionq_client import IonQClient
-from qiskit_ionq.helpers import get_n_qubits, retry
+from qiskit_ionq.helpers import get_backend_config, retry
 
 
 def test_user_agent_header():
@@ -51,54 +52,45 @@ def test_user_agent_header():
     assert all_user_agent_keywords_avail and has_all_version_strings
 
 
-def test_get_n_qubits_success():
-    """Test get_n_qubits returns correct number of qubits and checks correct URL."""
+def test_backend_config_success():
+    """get_backend_config returns the backend payload and hits the right URL."""
     with patch("requests.get") as mock_get:
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        payload = {
             "backend": "qpu.aria-1",
             "status": "unavailable",
-            "degraded": False,
             "qubits": 25,
-            "average_queue_time": 375478,
-            "last_updated": "2025-07-08T17:17:28Z",
-            "characterization_id": "b9b31a31-8d11-47c1-9156-87bd87954f7f",
+            "supported_gates": ["x", "cnot"],
+            "supported_native_gates": ["gpi", "gpi2", "ms"],
+            "supported_error_mitigations": ["Debias", "Sharpen"],
         }
+        mock_response = MagicMock()
+        mock_response.json.return_value = payload
+        mock_response.raise_for_status.return_value = None
         mock_get.return_value = mock_response
 
-        backend = "ionq_qpu.aria-1"
-        result = get_n_qubits(backend)
+        result = get_backend_config("ionq_qpu.aria-1")
 
         expected_url = "https://api.ionq.co/v0.4/backends/qpu.aria-1"
-
-        # Check the arguments of the last call to `requests.get`
         mock_get.assert_called()
         args, kwargs = mock_get.call_args
         actual_url = kwargs.get("url", args[0] if args else None)
-        assert (
-            actual_url == expected_url
-        ), f"Expected URL {expected_url}, but got {actual_url}"
-
-        assert result == 25, f"Expected 25 qubits, but got {result}"
+        assert actual_url == expected_url
+        assert result == payload
+        assert result["qubits"] == 25
 
 
-def test_get_n_qubits_fallback():
-    """Test get_n_qubits returns fallback number of qubits and checks correct URL on failure."""
+def test_backend_config_fallback():
+    """get_backend_config returns {} (with a warning) when the request fails."""
     with patch("requests.get", side_effect=Exception("Network error")) as mock_get:
-        backend = "aria-1"
-        result = get_n_qubits(backend)
+        with pytest.warns(UserWarning, match="Failed to fetch config"):
+            result = get_backend_config("aria-1")
 
         expected_url = "https://api.ionq.co/v0.4/backends/qpu.aria-1"
-
-        # Check the arguments of the last call to `requests.get`
         mock_get.assert_called()
         args, kwargs = mock_get.call_args
         actual_url = kwargs.get("url", args[0] if args else None)
-        assert (
-            actual_url == expected_url
-        ), f"Expected URL {expected_url}, but got {actual_url}"
-
-        assert result == 4, f"Expected fallback of 4 qubits, but got {result}"
+        assert actual_url == expected_url
+        assert result == {}
 
 
 def test_retry():

--- a/test/helpers/test_helpers.py
+++ b/test/helpers/test_helpers.py
@@ -100,11 +100,11 @@ def test_get_backends_success():
         assert result["qpu.tempo-1"]["qubits"] == 100
 
 
-def test_get_backends_fallback():
-    """get_backends returns {} (with a warning) when the request fails."""
-    with patch("requests.get", side_effect=Exception("Network error")):
-        with pytest.warns(UserWarning, match="Failed to fetch backends catalog"):
-            assert get_backends() == {}
+def test_get_backends_raises():
+    """get_backends propagates request failures."""
+    with patch("requests.get", side_effect=RuntimeError("Network error")):
+        with pytest.raises(RuntimeError, match="Network error"):
+            get_backends()
 
 
 def test_retry():

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -554,6 +554,17 @@ def test_qasm3_payload_shape(qpu_backend):
     assert header["memory_slots"] == 3
 
 
+def test_qasm3_strips_layout(qpu_backend):
+    """Transpiled circuits emit a virtual qubit register, not physical $0."""
+    isa = transpile(_mcm_circuit(), backend=qpu_backend, optimization_level=1)
+    assert isa.layout is not None  # transpile attached a layout
+    payload = json.loads(qiskit_to_ionq(isa, qpu_backend, passed_args={"shots": 10}))
+    data = payload["input"]["data"]
+    assert payload["type"] == "ionq.qasm3.v1"
+    assert "$" not in data  # no physical qubits
+    assert "qubit[" in data  # virtual register declared
+
+
 def test_qasm3_settings_passthrough(qpu_backend):
     """job_settings flow through and the ErrorMitigation enum merges in."""
     args = {

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -511,7 +511,7 @@ def test_capabilities_from_api(provider, monkeypatch, name, two_q):
         "supported_native_gates": ["gpi", "gpi2", two_q],
         "supported_error_mitigations": ["Debias", "Sharpen"],
     }
-    monkeypatch.setattr(provider, "backend_config", lambda _name: config)
+    monkeypatch.setattr(provider, "get_backend_config", lambda _name: config)
 
     backend = provider.get_backend(name, gateset="native")
     assert backend.num_qubits == 36
@@ -530,7 +530,7 @@ def test_capabilities_from_api(provider, monkeypatch, name, two_q):
 def test_capabilities_warn_offline(provider, monkeypatch):
     """An unavailable API config warns on capability access instead of
     silently returning an empty list."""
-    monkeypatch.setattr(provider, "backend_config", lambda _name: {})
+    monkeypatch.setattr(provider, "get_backend_config", lambda _name: {})
     backend = provider.get_backend("ionq_qpu.tempo-1")
 
     for prop in (

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -445,7 +445,7 @@ def test_dry_run_via_extra_params(mock_backend, requests_mock):
 
 
 def test_native_sim_target_noise(provider):
-    """Test that simulator native target uses ZZ gate for Forte noise models.
+    """Test that simulator native target uses ZZ gate for Forte/Tempo noise models.
 
     Args:
         provider (IonQProvider): A test IonQProvider.
@@ -465,6 +465,11 @@ def test_native_sim_target_noise(provider):
     target_ops = [op.name for op in sim_backend.target.operations]
     assert "ms" in target_ops
     assert "zz" not in target_ops
+
+    sim_backend.set_options(noise_model="tempo-1")
+    target_ops = [op.name for op in sim_backend.target.operations]
+    assert "zz" in target_ops
+    assert "ms" not in target_ops
 
 
 def test_forte_rzz_transpiles_to_zz(provider):

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -32,11 +32,15 @@ from collections import Counter
 
 import pytest
 from qiskit import QuantumCircuit, transpile
+from qiskit.transpiler import CouplingMap
 
-from qiskit_ionq import exceptions, ionq_client, ionq_job
+from qiskit_ionq import exceptions, ionq_backend, ionq_client, ionq_job
 from qiskit_ionq.helpers import get_user_agent
 
 from .. import conftest
+
+# Real _fetch_connectivity captured before the autouse fixture stubs it.
+_REAL_FETCH_CONNECTIVITY = ionq_backend.IonQBackend._fetch_connectivity
 
 
 def test_simulator_status_is_true(mock_backend):
@@ -445,13 +449,14 @@ def test_dry_run_via_extra_params(mock_backend, requests_mock):
 
 
 def test_native_sim_target_noise(provider):
-    """Test that simulator native target uses ZZ gate for Forte/Tempo noise models.
+    """Simulator native target picks its 2q gate from the noise model's config.
 
     Args:
         provider (IonQProvider): A test IonQProvider.
     """
     sim_backend = provider.get_backend("ionq_simulator", gateset="native")
 
+    # Default (ideal) has no real device -> historical ms default.
     target_ops = [op.name for op in sim_backend.target.operations]
     assert "ms" in target_ops
     assert "zz" not in target_ops
@@ -491,3 +496,101 @@ def test_forte_rzz_transpiles_to_zz(provider):
 
     assert "zz" in ops
     assert "ms" not in ops
+
+
+@pytest.mark.parametrize(
+    "name, two_q",
+    [("ionq_qpu.forte-1", "zz"), ("ionq_qpu.aria-1", "ms")],
+)
+def test_capabilities_from_api(provider, monkeypatch, name, two_q):
+    """Qubit count, native gateset, and capability lists come from the API config."""
+    config = {
+        "qubits": 36,
+        "supported_gates": ["x", "cnot"],
+        "supported_native_gates": ["gpi", "gpi2", two_q],
+        "supported_error_mitigations": ["Debias", "Sharpen"],
+    }
+    monkeypatch.setattr(ionq_backend, "get_backend_config", lambda *a, **k: config)
+
+    backend = provider.get_backend(name, gateset="native")
+    assert backend.num_qubits == 36
+    assert backend.supported_native_gates == ["gpi", "gpi2", two_q]
+    assert backend.supported_gates == ["x", "cnot"]
+    assert backend.supported_error_mitigations == ["Debias", "Sharpen"]
+    # native 2q gate is selected from supported_native_gates
+    assert two_q in [op.name for op in backend.target.operations]
+
+
+def test_tempo_qpu_target_zz(provider):
+    """A native-gateset Tempo QPU backend exposes ZZ (not MS).
+
+    Complements ``test_native_sim_target_noise`` (simulator noise-model path)
+    by exercising the QPU path, where the 2q gate is inferred from the backend
+    name rather than ``options.noise_model``.
+    """
+    tempo = provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+    target_ops = [op.name for op in tempo.target.operations]
+    assert "zz" in target_ops
+    assert "ms" not in target_ops
+    assert {"gpi", "gpi2"}.issubset(target_ops)
+
+
+def test_tempo_rzz_transpiles_to_zz(provider):
+    """rzz transpiles to zz (not ms) with a Tempo noise model."""
+    native_simulator = provider.get_backend("ionq_simulator", gateset="native")
+    native_simulator.set_options(noise_model="tempo-1")
+
+    qc = QuantumCircuit(2)
+    qc.rzz(1, 0, 1)
+
+    transpiled_qc = transpile(qc, backend=native_simulator, optimization_level=3)
+    ops = transpiled_qc.count_ops()
+
+    assert "zz" in ops
+    assert "ms" not in ops
+
+
+def test_coupling_map_restricted(provider):
+    """A genuine connectivity subset becomes a restricted, symmetric Target."""
+    tempo = provider.get_backend("ionq_qpu.tempo-1", gateset="native")
+    tempo._num_qubits = 5
+    chain = [(0, 1), (1, 2), (2, 3), (3, 4)]
+    expected = {(a, b) for x, y in chain for a, b in ((x, y), (y, x))}
+    with mock.patch.object(tempo, "_fetch_connectivity", return_value=chain):
+        assert set(tempo.coupling_map.get_edges()) == expected
+        assert tempo._restricted_coupling is True
+        # the 2q gate is scoped to exactly those pairs in the Target
+        assert set(tempo.target["zz"].keys()) == expected
+
+
+def test_coupling_map_complete(provider):
+    """A complete pair list (what Aria/Forte report) stays implicit all-to-all."""
+    forte = provider.get_backend("ionq_qpu.forte-1", gateset="native")
+    forte._num_qubits = 4
+    complete = [(i, j) for i in range(4) for j in range(i + 1, 4)]
+    with mock.patch.object(forte, "_fetch_connectivity", return_value=complete):
+        assert set(forte.coupling_map.get_edges()) == set(
+            CouplingMap.from_full(4).get_edges()
+        )
+        assert forte._restricted_coupling is False
+        # global 2q gate -> Target reports all-to-all
+        assert forte.target.build_coupling_map() is None
+
+
+def test_coupling_map_fallback(provider):
+    """No characterization connectivity (default) -> all-to-all, unrestricted."""
+    qpu = provider.get_backend("ionq_qpu.forte-1", gateset="native")
+    qpu._num_qubits = 3
+    # autouse fixture already stubs _fetch_connectivity -> None
+    assert set(qpu.coupling_map.get_edges()) == set(
+        CouplingMap.from_full(3).get_edges()
+    )
+    assert qpu._restricted_coupling is False
+
+
+def test_sim_skips_connectivity(provider):
+    """Simulators short-circuit connectivity (no network) and stay all-to-all."""
+    sim = provider.get_backend("ionq_simulator")
+    # Exercise the real method: it returns None for simulators before any call.
+    assert _REAL_FETCH_CONNECTIVITY(sim) is None
+    assert sim._restricted_coupling is False

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -27,6 +27,7 @@
 """Tests for the IonQ's Backend base/super-class."""
 # pylint: disable=redefined-outer-name
 
+import warnings
 from unittest import mock
 from collections import Counter
 
@@ -519,6 +520,26 @@ def test_capabilities_from_api(provider, monkeypatch, name, two_q):
     assert backend.supported_error_mitigations == ["Debias", "Sharpen"]
     # native 2q gate is selected from supported_native_gates
     assert two_q in [op.name for op in backend.target.operations]
+
+    # a populated config resolves capabilities silently
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert backend.supported_gates == ["x", "cnot"]
+
+
+def test_capabilities_warn_offline(provider, monkeypatch):
+    """An unavailable API config warns on capability access instead of
+    silently returning an empty list."""
+    monkeypatch.setattr(provider, "backend_config", lambda _name: {})
+    backend = provider.get_backend("ionq_qpu.tempo-1")
+
+    for prop in (
+        "supported_gates",
+        "supported_native_gates",
+        "supported_error_mitigations",
+    ):
+        with pytest.warns(UserWarning, match=f"{prop} is unknown"):
+            assert getattr(backend, prop) == []
 
 
 def test_tempo_qpu_target_zz(provider):

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -510,7 +510,7 @@ def test_capabilities_from_api(provider, monkeypatch, name, two_q):
         "supported_native_gates": ["gpi", "gpi2", two_q],
         "supported_error_mitigations": ["Debias", "Sharpen"],
     }
-    monkeypatch.setattr(ionq_backend, "get_backend_config", lambda *a, **k: config)
+    monkeypatch.setattr(provider, "backend_config", lambda _name: config)
 
     backend = provider.get_backend(name, gateset="native")
     assert backend.num_qubits == 36

--- a/test/ionq_client/test_artifact.py
+++ b/test/ionq_client/test_artifact.py
@@ -1,0 +1,66 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for IonQClient.get_artifact content-type handling."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from qiskit_ionq.ionq_client import IonQClient
+
+
+def _response(content_type, *, text=None, content=None):
+    res = MagicMock()
+    res.status_code = 200
+    res.headers = {"Content-Type": content_type}
+    res.text = text
+    res.content = content
+    return res
+
+
+@pytest.mark.parametrize(
+    "content_type, text, content, expected",
+    [
+        # JSON -> order-preserving dict (native/ore/result artifacts)
+        ("application/json", '{"qubits": 2}', None, {"qubits": 2}),
+        # text/plain -> str (compiled ionq.qasm3.v1)
+        ("text/plain; charset=utf-8", "OPENQASM 3.0;", None, "OPENQASM 3.0;"),
+        # octet-stream -> bytes (ionq.mir.v1)
+        ("application/octet-stream", None, b"\x08\x01", b"\x08\x01"),
+        # unknown content type but valid JSON body -> dict
+        ("", '{"a": 1}', None, {"a": 1}),
+        # unknown content type, non-JSON body -> str (no crash)
+        ("", "not json", None, "not json"),
+    ],
+)
+def test_get_artifact_by_type(content_type, text, content, expected):
+    """get_artifact decodes JSON, text, and binary artifacts by content type."""
+    client = IonQClient("token", "https://api.example.com/v0.4")
+    with patch(
+        "requests.get", return_value=_response(content_type, text=text, content=content)
+    ):
+        assert client.get_artifact("job-id", "artifact-id") == expected

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1519,6 +1519,41 @@ def test_qasm3_missing_reg_warns(mock_backend, requests_mock):
     assert res.get_counts() == {"01 0": 1}
 
 
+def test_qasm3_leaked_shots_excluded(mock_backend, requests_mock):
+    """Shots tagged with nonzero ``leakage_bits`` are invalid readouts and are
+    excluded from counts/memory, matching the platform's histogram and
+    probabilities aggregation (e.g. the staging stub's forced ~5% surplus)."""
+    job_id = "mcm_leak"
+    artifact_id = "shots-leak"
+    client = mock_backend.client
+    requests_mock.post(client.make_path("jobs"), json={"id": job_id})
+    requests_mock.get(
+        client.make_path("jobs", job_id),
+        json=_qasm3_job_response(job_id, artifact_id),
+    )
+    # An all-zero mask is "not leaked" and must still count; a set bit drops
+    # the whole shot.
+    zero_mask = {
+        "registers": {"mid": [0], "result": [0, 0], "output_all": [1]},
+        "leakage_bits": [0],
+    }
+    leaked = {
+        "registers": {"mid": [1], "result": [1, 1], "output_all": [1]},
+        "leakage_bits": [1],
+    }
+    requests_mock.get(
+        client.make_path("jobs", job_id, "artifacts", artifact_id),
+        json={"shots": _QASM3_SHOTS["shots"] + [zero_mask, leaked]},
+    )
+
+    job = mock_backend.run(_mcm_circuit(), shots=5, memory=True)
+    res = job.result()
+
+    # The leaked shot ("11 1") disappears; totals match the clean shot count.
+    assert res.get_counts() == {"00 0": 4, "01 1": 1}
+    assert len(res.get_memory()) == 5
+
+
 def test_qasm3_memory_false(mock_backend, requests_mock):
     """Without memory=True, MCM counts still decode but get_memory() raises."""
     job_id = "mcm_nomem"

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -1496,6 +1496,29 @@ def test_qasm3_high_bit(mock_backend, requests_mock):
     assert job.result().get_counts() == {"10 0": 1}
 
 
+def test_qasm3_missing_reg_warns(mock_backend, requests_mock):
+    """A declared register absent from the shots artifact warns instead of
+    silently reading as all zeros (e.g. compiler-elided measurements)."""
+    job_id = "mcm_missing"
+    artifact_id = "shots-missing"
+    client = mock_backend.client
+    requests_mock.post(client.make_path("jobs"), json={"id": job_id})
+    requests_mock.get(
+        client.make_path("jobs", job_id),
+        json=_qasm3_job_response(job_id, artifact_id),
+    )
+    # "mid" is declared in clbit_labels but absent from the artifact.
+    requests_mock.get(
+        client.make_path("jobs", job_id, "artifacts", artifact_id),
+        json={"shots": [{"registers": {"result": [1, 0], "output_all": [1]}}]},
+    )
+
+    job = mock_backend.run(_mcm_circuit(), shots=1)
+    with pytest.warns(UserWarning, match="missing from the job's shots"):
+        res = job.result()
+    assert res.get_counts() == {"01 0": 1}
+
+
 def test_qasm3_memory_false(mock_backend, requests_mock):
     """Without memory=True, MCM counts still decode but get_memory() raises."""
     job_id = "mcm_nomem"

--- a/test/ionq_provider/test_backend_service.py
+++ b/test/ionq_provider/test_backend_service.py
@@ -25,7 +25,19 @@
 # limitations under the License.
 """Test basic provider API methods."""
 
+import warnings
+
+import pytest
+
 from qiskit_ionq import IonQProvider
+
+# Real backend_config captured before the autouse fixture stubs it.
+_REAL_BACKEND_CONFIG = IonQProvider.backend_config
+
+_CATALOG = {
+    "qpu.aria-1": {"qubits": 25, "supported_native_gates": ["gpi", "gpi2", "ms"]},
+    "simulator": {"qubits": 29},
+}
 
 
 def test_provider_autocomplete():
@@ -60,3 +72,38 @@ def test_backend_eq():
     assert sub1 != sub2
     assert also_sub1 != sub2
     assert sub1 != simulator
+
+
+def test_backend_config_lookup():
+    """backend_config resolves local names against the cached catalog, silently."""
+    pro = IonQProvider("123456")
+    pro._catalog = _CATALOG
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _REAL_BACKEND_CONFIG(pro, "ionq_qpu.aria-1") == _CATALOG["qpu.aria-1"]
+        assert _REAL_BACKEND_CONFIG(pro, "ionq_simulator") == _CATALOG["simulator"]
+
+
+def test_backend_config_unknown_warns():
+    """An id missing from a populated catalog warns and returns {}."""
+    pro = IonQProvider("123456")
+    pro._catalog = _CATALOG
+    with pytest.warns(UserWarning, match="not in the IonQ catalog"):
+        assert _REAL_BACKEND_CONFIG(pro, "ionq_qpu.nope-1") == {}
+
+
+@pytest.mark.parametrize(
+    "name, catalog",
+    [
+        ("ionq_qpu", _CATALOG),  # generic template: no real device behind it
+        ("ionq_qpu.aria-1", {}),  # offline: the failed fetch already warned
+    ],
+)
+def test_backend_config_silent_defaults(name, catalog):
+    """The generic qpu template and an empty (offline) catalog resolve to {}
+    without re-warning."""
+    pro = IonQProvider("123456")
+    pro._catalog = catalog
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _REAL_BACKEND_CONFIG(pro, name) == {}

--- a/test/ionq_provider/test_backend_service.py
+++ b/test/ionq_provider/test_backend_service.py
@@ -29,10 +29,10 @@ import warnings
 
 import pytest
 
-from qiskit_ionq import IonQProvider
+from qiskit_ionq import IonQProvider, ionq_provider
 
-# Real backend_config captured before the autouse fixture stubs it.
-_REAL_BACKEND_CONFIG = IonQProvider.backend_config
+# Real get_backend_config captured before the autouse fixture stubs it.
+_REAL_GET_BACKEND_CONFIG = IonQProvider.get_backend_config
 
 _CATALOG = {
     "qpu.aria-1": {"qubits": 25, "supported_native_gates": ["gpi", "gpi2", "ms"]},
@@ -75,13 +75,15 @@ def test_backend_eq():
 
 
 def test_backend_config_lookup():
-    """backend_config resolves local names against the cached catalog, silently."""
+    """get_backend_config resolves local names against the cached catalog, silently."""
     pro = IonQProvider("123456")
     pro._catalog = _CATALOG
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        assert _REAL_BACKEND_CONFIG(pro, "ionq_qpu.aria-1") == _CATALOG["qpu.aria-1"]
-        assert _REAL_BACKEND_CONFIG(pro, "ionq_simulator") == _CATALOG["simulator"]
+        assert (
+            _REAL_GET_BACKEND_CONFIG(pro, "ionq_qpu.aria-1") == _CATALOG["qpu.aria-1"]
+        )
+        assert _REAL_GET_BACKEND_CONFIG(pro, "ionq_simulator") == _CATALOG["simulator"]
 
 
 def test_backend_config_unknown_warns():
@@ -89,7 +91,7 @@ def test_backend_config_unknown_warns():
     pro = IonQProvider("123456")
     pro._catalog = _CATALOG
     with pytest.warns(UserWarning, match="not in the IonQ catalog"):
-        assert _REAL_BACKEND_CONFIG(pro, "ionq_qpu.nope-1") == {}
+        assert _REAL_GET_BACKEND_CONFIG(pro, "ionq_qpu.nope-1") == {}
 
 
 @pytest.mark.parametrize(
@@ -106,4 +108,40 @@ def test_backend_config_silent_defaults(name, catalog):
     pro._catalog = catalog
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        assert _REAL_BACKEND_CONFIG(pro, name) == {}
+        assert _REAL_GET_BACKEND_CONFIG(pro, name) == {}
+
+
+def test_catalog_fetched_on_get_backend_not_init(monkeypatch):
+    """The catalog is fetched on first get_backend, not at construction,
+    and cached."""
+    calls = []
+
+    def fake_get_backends(*_args, **_kwargs):
+        calls.append(1)
+        return _CATALOG
+
+    monkeypatch.setattr(ionq_provider, "get_backends", fake_get_backends)
+    monkeypatch.setattr(
+        ionq_provider.IonQProvider, "get_backend_config", _REAL_GET_BACKEND_CONFIG
+    )
+    pro = IonQProvider("123456")
+    assert not calls  # construction is network-free
+    pro.get_backend("ionq_qpu.aria-1")
+    assert len(calls) == 1
+    pro.get_backend("ionq_simulator")
+    assert len(calls) == 1  # cached; no refetch
+
+
+def test_catalog_fetch_failure_warns_and_caches(monkeypatch):
+    """A failed fetch warns once and caches an empty catalog."""
+
+    def raise_offline(*_args, **_kwargs):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(ionq_provider, "get_backends", raise_offline)
+    pro = IonQProvider("123456")
+    with pytest.warns(UserWarning, match="Failed to fetch backends catalog"):
+        assert _REAL_GET_BACKEND_CONFIG(pro, "ionq_qpu.aria-1") == {}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _REAL_GET_BACKEND_CONFIG(pro, "ionq_qpu.aria-1") == {}

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ commands = make html
 filterwarnings =
   error::DeprecationWarning
   error::PendingDeprecationWarning
-  ignore:Failed to get qubits .* Using 4:UserWarning:qiskit_ionq\.helpers
   ignore:Retrying .* more time\(s\) after .*:UserWarning:qiskit_ionq\.helpers
   ignore:TimedOut:UserWarning:qiskit_ionq\.ionq_job
   ignore:The parameter\(s\).*not checked by default.*submitted in the request\.:UserWarning:qiskit_ionq\.ionq_client


### PR DESCRIPTION
Builds each backend's `Target` from the `/backends/{id}` API instead of hardcoded device data - groundwork for **Tempo** (`qpu.tempo-1` now resolves with no device-specific code).

- Replaced `get_n_qubits()` with `get_backend_config()` (one API call); deleted the `NATIVE_2Q_BY_FAMILY` map and `native_2q_gate()` heuristic.
- Qubit count, native 2q gate (`supported_native_gates`), and connectivity (→ coupling map) now come from the API.
- Added `supported_gates` / `supported_native_gates` / `supported_error_mitigations` properties.
- qasm3 (MCM) results: shots tagged with nonzero `leakage_bits` in the shots-v2 artifact are excluded from counts/memory, matching the platform's histogram/probabilities aggregation (verified against staging tempo-1, where the stub inflates every job by ~5% forced-leaked shots).
